### PR TITLE
Make JSON iterator return non-const JsonElement

### DIFF
--- a/libutils/json.c
+++ b/libutils/json.c
@@ -521,7 +521,7 @@ const char *JsonIteratorNextKey(JsonIterator *iter)
     return child ? child->propertyName : NULL;
 }
 
-const JsonElement *JsonIteratorNextValue(JsonIterator *iter)
+JsonElement *JsonIteratorNextValue(JsonIterator *iter)
 {
     assert(iter);
     assert(iter->container->type == JSON_ELEMENT_TYPE_CONTAINER);
@@ -534,9 +534,9 @@ const JsonElement *JsonIteratorNextValue(JsonIterator *iter)
     return iter->container->container.children->data[iter->index++];
 }
 
-const JsonElement *JsonIteratorNextValueByType(JsonIterator *iter, JsonElementType type, bool skip_null)
+JsonElement *JsonIteratorNextValueByType(JsonIterator *iter, JsonElementType type, bool skip_null)
 {
-    const JsonElement *e = NULL;
+    JsonElement *e = NULL;
     while ((e = JsonIteratorNextValue(iter)))
     {
         if (skip_null
@@ -555,7 +555,7 @@ const JsonElement *JsonIteratorNextValueByType(JsonIterator *iter, JsonElementTy
     return NULL;
 }
 
-const JsonElement *JsonIteratorCurrentValue(const JsonIterator *iter)
+JsonElement *JsonIteratorCurrentValue(const JsonIterator *iter)
 {
     assert(iter);
     assert(iter->container->type == JSON_ELEMENT_TYPE_CONTAINER);

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -423,10 +423,10 @@ const char *JsonPrimitiveTypeToString(JsonPrimitiveType type);
 
 JsonIterator JsonIteratorInit(const JsonElement *container);
 const char *JsonIteratorNextKey(JsonIterator *iter);
-const JsonElement *JsonIteratorNextValue(JsonIterator *iter);
-const JsonElement *JsonIteratorNextValueByType(JsonIterator *iter, JsonElementType type, bool skip_null);
+JsonElement *JsonIteratorNextValue(JsonIterator *iter);
+JsonElement *JsonIteratorNextValueByType(JsonIterator *iter, JsonElementType type, bool skip_null);
 const char *JsonIteratorCurrentKey(const JsonIterator *iter);
-const JsonElement *JsonIteratorCurrentValue(const JsonIterator *iter);
+JsonElement *JsonIteratorCurrentValue(const JsonIterator *iter);
 JsonElementType JsonIteratorCurrentElementType(const JsonIterator *iter);
 JsonContainerType JsonIteratorCurrentContainerType(const JsonIterator *iter);
 JsonPrimitiveType JsonIteratorCurrentPrimitiveType(const JsonIterator *iter);


### PR DESCRIPTION
The container being iterated over should be read-only (to avoid
issues with iterating over a modifying structure). But the child
objects the iterator returns should be modifiabler/read-write,
changing those is not a problem.