### PR TITLE
Fixed issue with including pcre.h on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -469,7 +469,7 @@ fi
 
 CF3_WITH_LIBRARY(pcre, [
   AC_CHECK_LIB(pcre, pcre_exec, [], [AC_MSG_ERROR(Cannot find PCRE)])
-  AC_CHECK_HEADERS([pcre.h], [PCRE_CPPFLAGS=""],
+  AC_CHECK_HEADERS([pcre.h], [],
     [AC_CHECK_HEADERS([pcre/pcre.h], [PCRE_CPPFLAGS="-Ipcre"],
                       AC_MSG_ERROR(Cannot find PCRE))])
 ])


### PR DESCRIPTION
It seems this variable already had a value, with the include
path of the header, so overwriting it here was a bad idea.

We should probably fix the line below as well, but I don't
know what's appropriate, and this patch was enough to fix
my problems when building on OpenBSD.