### PR TITLE
Added user flags from configure to libutils AM_CFLAGS.

### DIFF
--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -24,9 +24,9 @@
 noinst_LTLIBRARIES = libutils.la
 
 # TODO remove the openssl dependency! It's only there for base64 encoding.
-AM_CFLAGS   = $(PCRE_CFLAGS) $(OPENSSL_CFLAGS)
-AM_CPPFLAGS = $(PCRE_CPPFLAGS) $(OPENSSL_CPPFLAGS)
-AM_LDFLAGS  = $(PCRE_LDFLAGS) $(OPENSSL_LDFLAGS)
+AM_CFLAGS   = @CFLAGS@   $(PCRE_CFLAGS)   $(OPENSSL_CFLAGS)
+AM_CPPFLAGS = @CPPFLAGS@ $(PCRE_CPPFLAGS) $(OPENSSL_CPPFLAGS)
+AM_LDFLAGS  = @LDLAGS@   $(PCRE_LDFLAGS)  $(OPENSSL_LDFLAGS)
 
 libutils_la_LIBADD = ../libcompat/libcompat.la
 libutils_la_LIBS   = $(PCRE_LIBS) $(OPENSSL_LIBS)


### PR DESCRIPTION
Overriding CFLAGS in configure is not correct, according to:

https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html

However, we already do this, and it seems quite common:

https://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_check_enable_debug.m4

And we already do this substitution in other Makefile.am files.
So, for now, I think it's better to try to be consistent.

This patch allows you to do something like this:

```
$ ./autogen.sh --enable-debug
$ make -j2 CFLAGS='-Werror -Wall -Wno-pointer-sign'
```

And still get debugging information (line numbers in gdb) for
libutils. Previously, the explicit `CFLAGS` in make command
would override the `-g` option from `--enable-debug`

Changelog: None
Ticket: None
Signed-off-by: Ole Herman Schumacher Elgesem <ole@northern.tech>