### PR TITLE
Added stack_base.c to EXTRA_DIST

### DIFF
--- a/libutils/Makefile.am
+++ b/libutils/Makefile.am
@@ -85,6 +85,8 @@ libutils_la_SOURCES = \
 	writer.c writer.h \
 	xml_writer.c xml_writer.h
 
+EXTRA_DIST = stack_base.c
+
 if !NT
 libutils_la_SOURCES += unix_dir.c
 endif


### PR DESCRIPTION
Should be part of dist tarball, but not compiled directly.
This commit makes it possible to run `make dist`, and then
`./configure && make` inside the expanded tarball, without
errors.

`stack_base.c` is not in `_SOURCES`, because it includes
static functions and definitions which are needed in both
`stack.c` and `threaded_stack.c`. Compiling it directly
would cause warnings about unused static functions.

This is also explained in `stack_base.c`:

```
/** @file stack_base.c
 * @brief Shared code between threaded_stack.c and stack.c
 *
 * This file should be included, not compiled separately.
 */
```