### PR TITLE
Travis: Fixed code coverage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1235,25 +1235,6 @@ dnl ######################################################################
 AC_ARG_ENABLE([selinux], [AS_HELP_STRING([--enable-selinux], [Deprecated. SELinux support is always enabled])])
 
 dnl ######################################################################
-dnl Collect all the options
-dnl ######################################################################
-
-CORE_CPPFLAGS="$LMDB_CPPFLAGS $TOKYOCABINET_CPPFLAGS $QDBM_CPPFLAGS $PCRE_CPPFLAGS $OPENSSL_CPPFLAGS $SQLITE3_CPPFLAGS $LIBACL_CPPFLAGS $LIBCURL_CPPFLAGS $LIBYAML_CPPFLAGS $POSTGRESQL_CPPFLAGS $MYSQL_CPPFLAGS $LIBXML2_CPPFLAGS $CPPFLAGS"
-CORE_CFLAGS="$LMDB_CFLAGS $TOKYOCABINET_CFLAGS $QDBM_CFLAGS $PCRE_CFLAGS $OPENSSL_CFLAGS $SQLITE3_CFLAGS $LIBACL_CFLAGS $LIBCURL_CFLAGS $LIBYAML_CFLAGS $POSTGRESQL_CFLAGS $MYSQL_CFLAGS $LIBXML2_CFLAGS $CFLAGS"
-CORE_LDFLAGS="$LMDB_LDFLAGS $TOKYOCABINET_LDFLAGS $QDBM_LDFLAGS $PCRE_LDFLAGS $OPENSSL_LDFLAGS $SQLITE3_LDFLAGS $LIBACL_LDFLAGS $LIBCURL_LDFLAGS $LIBYAML_LDFLAGS $POSTGRESQL_LDFLAGS $MYSQL_LDFLAGS $LIBXML2_LDFLAGS $LDFLAGS"
-CORE_LIBS="$LMDB_LIBS $TOKYOCABINET_LIBS $QDBM_LIBS $PCRE_LIBS $OPENSSL_LIBS $SQLITE3_LIBS $LIBACL_LIBS $LIBCURL_LIBS $LIBYAML_LIBS $POSTGRESQL_LIBS $MYSQL_LIBS $LIBXML2_LIBS $LIBS"
-
-dnl ######################################################################
-dnl Make them available to subprojects.
-dnl ######################################################################
-
-AC_SUBST([CORE_CPPFLAGS])
-AC_SUBST([CORE_CFLAGS])
-AC_SUBST([CORE_LDFLAGS])
-AC_SUBST([CORE_LIBS])
-AC_CONFIG_FILES([configure_flags.env])
-
-dnl ######################################################################
 dnl OS specific stuff
 dnl ######################################################################
 
@@ -1496,6 +1477,25 @@ if test "x$use_coverage" = "xyes"; then
 else
   AM_CONDITIONAL([ENABLE_COVERAGE], false)
 fi
+
+dnl ######################################################################
+dnl Collect all the options
+dnl ######################################################################
+
+CORE_CPPFLAGS="$LMDB_CPPFLAGS $TOKYOCABINET_CPPFLAGS $QDBM_CPPFLAGS $PCRE_CPPFLAGS $OPENSSL_CPPFLAGS $SQLITE3_CPPFLAGS $LIBACL_CPPFLAGS $LIBCURL_CPPFLAGS $LIBYAML_CPPFLAGS $POSTGRESQL_CPPFLAGS $MYSQL_CPPFLAGS $LIBXML2_CPPFLAGS $CPPFLAGS"
+CORE_CFLAGS="$LMDB_CFLAGS $TOKYOCABINET_CFLAGS $QDBM_CFLAGS $PCRE_CFLAGS $OPENSSL_CFLAGS $SQLITE3_CFLAGS $LIBACL_CFLAGS $LIBCURL_CFLAGS $LIBYAML_CFLAGS $POSTGRESQL_CFLAGS $MYSQL_CFLAGS $LIBXML2_CFLAGS $CFLAGS"
+CORE_LDFLAGS="$LMDB_LDFLAGS $TOKYOCABINET_LDFLAGS $QDBM_LDFLAGS $PCRE_LDFLAGS $OPENSSL_LDFLAGS $SQLITE3_LDFLAGS $LIBACL_LDFLAGS $LIBCURL_LDFLAGS $LIBYAML_LDFLAGS $POSTGRESQL_LDFLAGS $MYSQL_LDFLAGS $LIBXML2_LDFLAGS $LDFLAGS"
+CORE_LIBS="$LMDB_LIBS $TOKYOCABINET_LIBS $QDBM_LIBS $PCRE_LIBS $OPENSSL_LIBS $SQLITE3_LIBS $LIBACL_LIBS $LIBCURL_LIBS $LIBYAML_LIBS $POSTGRESQL_LIBS $MYSQL_LIBS $LIBXML2_LIBS $LIBS"
+
+dnl ######################################################################
+dnl Make them available to subprojects.
+dnl ######################################################################
+
+AC_SUBST([CORE_CPPFLAGS])
+AC_SUBST([CORE_CFLAGS])
+AC_SUBST([CORE_LDFLAGS])
+AC_SUBST([CORE_LIBS])
+AC_CONFIG_FILES([configure_flags.env])
 
 #
 # Populate contents of config.post.h

--- a/travis-scripts/after_success.sh
+++ b/travis-scripts/after_success.sh
@@ -5,4 +5,7 @@
 sudo chown -R $USER  .  ||  true
 
 # Code coverage by codecov.io
-curl -s https://codecov.io/bash | bash
+if [ "x$COVERAGE" != xno ]
+then
+    curl -s https://codecov.io/bash | bash
+fi


### PR DESCRIPTION
Previously, when explicit `CFLAGS`/`LDFLAGS` were set, they
would override the coverage flags from `configure.ac`
(`--enable-coverage`). Other similar flags are substituted using
the `CORE_CFLAGS`, `CORE_LDFLAGS`, etc. However, this was done
too early to capture the flags from `--enable-coverage`.