### PR TITLE
hash.h: ensure type 'bool' has been declared

### DIFF
--- a/libutils/hash.h
+++ b/libutils/hash.h
@@ -29,6 +29,7 @@
   @brief Hash implementations
   */
 
+#include <stdbool.h>
 #include <openssl/rsa.h>
 #include <openssl/evp.h>
 


### PR DESCRIPTION
"hash.h" uses type 'bool' in some declarations. When various files in CFEngine include "hash.h" the 'bool' type might not have been included.  This commit ensures the validity of 'bool'.