### PR TITLE
Include platform.h before pthread.h

### DIFF
--- a/libutils/threaded_deque.c
+++ b/libutils/threaded_deque.c
@@ -22,11 +22,12 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
+#include <threaded_deque.h>
 #include <alloc.h>
 #include <logging.h>
 #include <mutex.h>
 #include <pthread.h>
-#include <threaded_deque.h>
 
 
 #define EXPAND_FACTOR     2

--- a/libutils/threaded_queue.c
+++ b/libutils/threaded_queue.c
@@ -22,11 +22,12 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
+#include <threaded_queue.h>
 #include <alloc.h>
 #include <logging.h>
 #include <mutex.h>
 #include <pthread.h>
-#include <threaded_queue.h>
 
 
 #define EXPAND_FACTOR     2

--- a/libutils/threaded_stack.c
+++ b/libutils/threaded_stack.c
@@ -22,12 +22,12 @@
   included file COSL.txt.
 */
 
+#include <platform.h>
+#include <threaded_stack.h>
 #include <alloc.h>
 #include <logging.h>
 #include <mutex.h>
 #include <pthread.h>
-
-#include <threaded_stack.h>
 #include <stack_base.c>
 
 /** @struct ThreadedStack_


### PR DESCRIPTION
When compiling on Debian 6 (in core) errors were encountered,
because, on this platform, it's important to set some
OPEN_SOURCE macro before including `pthread.h`:

https://stackoverflow.com/questions/18375527/why-is-gnu-source-macro-required-for-pthread-mutexattr-settype-while-it-is-in