### PR TITLE
Fix CPPFLAGS for the new file_locks_test unit tests

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -186,5 +186,4 @@ threaded_deque_test_SOURCES = threaded_deque_test.c
 threaded_stack_test_SOURCES = threaded_stack_test.c
 
 file_lock_test_SOURCES = file_lock_test.c
-file_lock_test_CPPFLAGS = -I$(top_srcdir)/libutils
 file_lock_test_LDADD = ../../libutils/libutils.la


### PR DESCRIPTION
We need some extra include folders to be able to build in
environments where devel packages are installed in /var/cfengine.