### PR TITLE
Add a missing include for GetErrorStr() on Windows

### DIFF
--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -28,6 +28,9 @@
 #include <misc_lib.h>
 #include <cleanup.h>
 
+#ifdef __MINGW32__
+#include <definitions.h>        /* CF_BUFSIZE */
+#endif
 
 char VPREFIX[1024] = ""; /* GLOBAL_C */
 


### PR DESCRIPTION
It's using a buffer the size of which is specified as CF_BUFSIZE.