### PR TITLE
Added O_EXCL for safe_fopen

### DIFF
--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -831,6 +831,9 @@ FILE *safe_fopen_create_perms(
         case 't':
             flags |= O_TEXT;
             break;
+        case 'x':
+            flags |= O_EXCL;
+            break;
         default:
             ProgrammingError("Invalid flag for fopen: %s", mode);
             return NULL;


### PR DESCRIPTION
Same as additions made in glibc. Check NOTES under `man 3 fopen`.

Ticket: None
Changelog: None