### PR TITLE
Added StringCloseHole() from core

### DIFF
--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -1187,6 +1187,19 @@ size_t TrimCSVLineCRLFStrict(char *const data)
     return length;
 }
 
+void StringCloseHole(char *s, const int start, const int end)
+{
+    assert(s != NULL);
+    assert(0 <= start && start <= end && end <= strlen(s));
+    assert((end - start) <= strlen(s));
+
+    if (end > start)
+    {
+        memmove(s + start, s + end,
+                /* The 1+ ensures we copy the final '\0' */
+                strlen(s + end) + 1);
+    }
+}
 
 bool StringEndsWithCase(const char *str, const char *suffix, const bool case_fold)
 {

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -171,6 +171,15 @@ size_t TrimCSVLineCRLF(char *data);
 size_t TrimCSVLineCRLFStrict(char *data);
 
 /**
+ * @brief Erase part of a string using memmove()
+ *
+ * String must be NUL-terminated. Indices from start, up to but not including
+ * end are erased. The number of bytes erased is end - start. If start == end,
+ * no bytes are erased. Assumes: 0 <= start <= end <= strlen(s)
+ */
+void StringCloseHole(char *s, int start, int end);
+
+/**
  * @brief Check if a string ends with the given suffix
  * @param str
  * @param suffix

--- a/tests/unit/string_lib_test.c
+++ b/tests/unit/string_lib_test.c
@@ -850,6 +850,26 @@ static void test_trim_crlf(void)
     }
 }
 
+static void test_close_hole(void)
+{
+    char *test_string = xstrdup("test");
+    StringCloseHole(test_string, 0, 0);
+    assert_string_equal(test_string, "test");
+    StringCloseHole(test_string, 4, 4);
+    assert_string_equal(test_string, "test");
+
+    size_t length = strlen(test_string);
+    StringCloseHole(test_string, length - 1, length);
+    assert_string_equal(test_string, "tes");
+    StringCloseHole(test_string, 0, 1);
+    assert_string_equal(test_string, "es");
+    StringCloseHole(test_string, 1, 2);
+    assert_string_equal(test_string, "e");
+    StringCloseHole(test_string, 0, 1);
+    assert_string_equal(test_string, "");
+    free(test_string);
+}
+
 static void test_ends_with(void)
 {
     assert_true(StringEndsWith("file.json", ".json"));
@@ -1264,6 +1284,7 @@ int main()
         unit_test(test_chop_empty_two_spaces),
 
         unit_test(test_trim_crlf),
+        unit_test(test_close_hole),
 
         unit_test(test_ends_with),
 


### PR DESCRIPTION
This was a static function in core, called CloseStringHole().
Added asserts, tests, and a doxygen comment.