### PR TITLE
Refactor json-utils, put `JsonParseAnyFile` in json.h header

### DIFF
--- a/libutils/json-utils.h
+++ b/libutils/json-utils.h
@@ -27,9 +27,24 @@
 
 #include <json.h>
 
+typedef enum {
+    DATAFILETYPE_UNKNOWN = 0,
+    DATAFILETYPE_JSON,
+    DATAFILETYPE_YAML,
+    DATAFILETYPE_ENV,
+    DATAFILETYPE_CSV
+} DataFileType;
+
 void ParseEnvLine(char *raw_line, char **key_out, char **value_out, const char *filename_for_log, int linenumber);
 bool JsonParseEnvFile(const char *input_path, size_t size_max, JsonElement **json_out);
 bool JsonParseCsvFile(const char *path, size_t size_max, JsonElement **json_out);
-JsonElement *JsonReadDataFile(const char *log_identifier, const char *input_path, const char *requested_mode, size_t size_max);
+JsonElement *JsonReadDataFile(
+        const char *log_identifier,
+        const char *input_path,
+        DataFileType requested_mode,
+        size_t size_max);
+DataFileType GetDataFileTypeFromString(const char *requested_mode);
+DataFileType GetDataFileTypeFromSuffix(const char *filename);
+const char *DataFileTypeToString(DataFileType type);
 
 #endif // CFENGINE_JSON_UTILS_H

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -478,7 +478,21 @@ JsonParseError JsonParseWithLookup(
     JsonElement **json_out);
 
 /**
- * @brief Convenience function to parse JSON from a file
+ * @brief Convenience function to parse JSON or YAML from a file
+ * @param path Path to the file
+ * @param size_max Maximum size to read in memory
+ * @param json_out Resulting JSON object
+ * @param yaml_format Whether or not the file is in yaml format
+ * @return See JsonParseError and JsonParseErrorToString
+ */
+JsonParseError JsonParseAnyFile(
+    const char *path,
+    size_t size_max,
+    JsonElement **json_out,
+    bool yaml_format);
+
+/**
+ * @brief Convenience function to parse JSON from a file.
  * @param path Path to the file
  * @param size_max Maximum size to read in memory
  * @param json_out Resulting JSON object


### PR DESCRIPTION
Refactoring includes:
  - Put `FileType` in `json-utils` and make it an enum instead
    (previously just returned a string)
  - Added utility function to get a string from the new enums
  - Added JsonParseAnyFile to `json.h`. It wasn't static, and is
    actually (slightly) useful outside `json.c`

Note that this needs to be merged with a libpromises patch that replaces
the use of `JsonReadDataFile`

Ticket: None
Changelog: None

I was unsure of whether to split this into several commits or not. It should be fairly easy to review I think.