### PR TITLE
Added enum JsonType and GetJsonType()

### DIFF
--- a/libutils/json.c
+++ b/libutils/json.c
@@ -584,8 +584,7 @@ JsonElement *JsonIteratorNextValueByType(
     JsonElement *e = NULL;
     while ((e = JsonIteratorNextValue(iter)))
     {
-        if (skip_null && JsonGetElementType(e) == JSON_ELEMENT_TYPE_PRIMITIVE
-            && JsonGetPrimitiveType(e) == JSON_PRIMITIVE_TYPE_NULL)
+        if (skip_null && JsonGetType(e) == JSON_TYPE_NULL)
         {
             continue;
         }
@@ -668,6 +667,17 @@ JsonElementType JsonGetElementType(const JsonElement *const element)
     assert(element != NULL);
 
     return element->type;
+}
+
+JsonType JsonGetType(const JsonElement *element)
+{
+    if (JsonGetElementType(element) == JSON_ELEMENT_TYPE_CONTAINER)
+    {
+        return (JsonType) JsonGetContainerType(element);
+    }
+
+    assert(JsonGetElementType(element) == JSON_ELEMENT_TYPE_PRIMITIVE);
+    return (JsonType) JsonGetPrimitiveType(element);
 }
 
 JsonContainerType JsonGetContainerType(const JsonElement *const container)

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -49,24 +49,35 @@
 
 typedef enum
 {
-    JSON_ELEMENT_TYPE_CONTAINER,
-    JSON_ELEMENT_TYPE_PRIMITIVE
+    JSON_ELEMENT_TYPE_CONTAINER = 1,
+    JSON_ELEMENT_TYPE_PRIMITIVE = 2,
 } JsonElementType;
 
 typedef enum
 {
-    JSON_CONTAINER_TYPE_OBJECT,
-    JSON_CONTAINER_TYPE_ARRAY
+    JSON_CONTAINER_TYPE_OBJECT = 3,
+    JSON_CONTAINER_TYPE_ARRAY = 4,
 } JsonContainerType;
 
 typedef enum
 {
-    JSON_PRIMITIVE_TYPE_STRING,
-    JSON_PRIMITIVE_TYPE_INTEGER,
-    JSON_PRIMITIVE_TYPE_REAL,
-    JSON_PRIMITIVE_TYPE_BOOL,
-    JSON_PRIMITIVE_TYPE_NULL
+    JSON_PRIMITIVE_TYPE_STRING = 5,
+    JSON_PRIMITIVE_TYPE_INTEGER = 6,
+    JSON_PRIMITIVE_TYPE_REAL = 7,
+    JSON_PRIMITIVE_TYPE_BOOL = 8,
+    JSON_PRIMITIVE_TYPE_NULL = 9,
 } JsonPrimitiveType;
+
+typedef enum
+{
+    JSON_TYPE_OBJECT = JSON_CONTAINER_TYPE_OBJECT,
+    JSON_TYPE_ARRAY = JSON_CONTAINER_TYPE_ARRAY,
+    JSON_TYPE_STRING = JSON_PRIMITIVE_TYPE_STRING,
+    JSON_TYPE_INTEGER = JSON_PRIMITIVE_TYPE_INTEGER,
+    JSON_TYPE_REAL = JSON_PRIMITIVE_TYPE_REAL,
+    JSON_TYPE_BOOL = JSON_PRIMITIVE_TYPE_BOOL,
+    JSON_TYPE_NULL = JSON_PRIMITIVE_TYPE_NULL,
+} JsonType;
 
 typedef enum
 {
@@ -169,6 +180,7 @@ void JsonDestroyMaybe(JsonElement *element, bool allocated);
 size_t JsonLength(const JsonElement *element);
 
 JsonElementType JsonGetElementType(const JsonElement *element);
+JsonType JsonGetType(const JsonElement *element);
 const char *JsonElementGetPropertyName(const JsonElement *element);
 
 const char *JsonGetPropertyAsString(const JsonElement *element);

--- a/libutils/mustache.c
+++ b/libutils/mustache.c
@@ -165,7 +165,7 @@ static JsonElement *LookupVariable(Seq *hash_stack, const char *name, size_t nam
                 continue;
             }
 
-            if (JsonGetElementType(hash) == JSON_ELEMENT_TYPE_CONTAINER && JsonGetContainerType(hash) == JSON_CONTAINER_TYPE_OBJECT)
+            if (JsonGetType(hash) == JSON_TYPE_OBJECT)
             {
                 JsonElement *var = JsonObjectGet(hash, base_comp_str);
                 if (var)
@@ -185,7 +185,7 @@ static JsonElement *LookupVariable(Seq *hash_stack, const char *name, size_t nam
 
     for (size_t i = 1; i < num_comps; i++)
     {
-        if (JsonGetElementType(base_var) != JSON_ELEMENT_TYPE_CONTAINER || JsonGetContainerType(base_var) != JSON_CONTAINER_TYPE_OBJECT)
+        if (JsonGetType(base_var) != JSON_TYPE_OBJECT)
         {
             return NULL;
         }

--- a/tests/unit/json_test.c
+++ b/tests/unit/json_test.c
@@ -659,9 +659,7 @@ static void test_parse_empty_containers(void)
         JsonElement *obj = NULL;
         assert_int_equal(JSON_PARSE_OK, JsonParse(&data, &obj));
         assert_true(obj != NULL);
-        assert_int_equal(JSON_ELEMENT_TYPE_CONTAINER, JsonGetElementType(obj));
-        assert_int_equal(
-            JSON_CONTAINER_TYPE_OBJECT, JsonGetContainerType(obj));
+        assert_int_equal(JSON_TYPE_OBJECT, JsonGetType(obj));
         assert_int_equal(0, JsonLength(obj));
         JsonDestroy(obj);
     }
@@ -673,6 +671,8 @@ static void test_parse_empty_containers(void)
         assert_true(arr != NULL);
         assert_int_equal(JSON_ELEMENT_TYPE_CONTAINER, JsonGetElementType(arr));
         assert_int_equal(JSON_CONTAINER_TYPE_ARRAY, JsonGetContainerType(arr));
+        assert_int_equal(JSON_TYPE_ARRAY, JsonGetType(arr));
+        assert_int_equal(JsonGetContainerType(arr), JsonGetType(arr));
         assert_int_equal(0, JsonLength(arr));
         JsonDestroy(arr);
     }


### PR DESCRIPTION
When validating json, you usually want to know whether an
element is exactly the type it should be. First checking
ElementType and then PrimitiveType / ContainterType is tedious,
makes the code harder to read, and more prone to error.

Could be cleaned up in many places, but this is enough for now.
I want to use this in `classfilterdata()`.