### PR TITLE
ENT-4829: Added possibility to not terminate last line of CSV writer

### DIFF
--- a/libutils/csv_writer.c
+++ b/libutils/csv_writer.c
@@ -30,6 +30,7 @@ struct CsvWriter_
 {
     Writer *w;
     bool beginning_of_line;
+    bool terminate_last_line;
 };
 
 /*****************************************************************************/
@@ -39,13 +40,19 @@ static void CsvWriterFieldVF(CsvWriter * csvw, const char *fmt, va_list ap) FUNC
 
 /*****************************************************************************/
 
-CsvWriter *CsvWriterOpen(Writer *w)
+CsvWriter *CsvWriterOpenSpecifyTerminate(Writer *w, bool terminate_last_line)
 {
     CsvWriter *csvw = xmalloc(sizeof(CsvWriter));
 
     csvw->w = w;
     csvw->beginning_of_line = true;
+    csvw->terminate_last_line = terminate_last_line;
     return csvw;
+}
+
+CsvWriter *CsvWriterOpen(Writer *w)
+{
+    return CsvWriterOpenSpecifyTerminate(w, true);
 }
 
 /*****************************************************************************/
@@ -94,7 +101,9 @@ void CsvWriterNewRecord(CsvWriter * csvw)
 
 void CsvWriterClose(CsvWriter * csvw)
 {
-    if (!csvw->beginning_of_line)
+    assert(csvw != NULL);
+
+    if (!csvw->beginning_of_line && csvw->terminate_last_line)
     {
         WriterWrite(csvw->w, "\r\n");
     }

--- a/libutils/csv_writer.h
+++ b/libutils/csv_writer.h
@@ -34,6 +34,7 @@
 
 typedef struct CsvWriter_ CsvWriter;
 
+CsvWriter *CsvWriterOpenSpecifyTerminate(Writer *w, bool terminate_last_line);
 CsvWriter *CsvWriterOpen(Writer *w);
 
 void CsvWriterField(CsvWriter *csvw, const char *str);

--- a/tests/unit/csv_writer_test.c
+++ b/tests/unit/csv_writer_test.c
@@ -100,6 +100,64 @@ void test_escape(void)
     free(result_string);
 }
 
+void test_terminate(void)
+{
+    Writer *w = StringWriter();
+    CsvWriter *c = CsvWriterOpenSpecifyTerminate(w, true);
+
+    CsvWriterField(c, "test");
+
+    CsvWriterClose(c);
+    char *result_string = StringWriterClose(w);
+    assert_string_equal(result_string, "test\r\n");
+    free(result_string);
+}
+
+void test_no_terminate(void)
+{
+    {
+        Writer *w = StringWriter();
+
+        CsvWriter *c = CsvWriterOpenSpecifyTerminate(w, false);
+        CsvWriterField(c, "test");
+        CsvWriterClose(c);
+
+        char *result_string = StringWriterClose(w);
+        assert_string_equal(result_string, "test");
+        free(result_string);
+    }
+    {
+        Writer *w = StringWriter();
+
+        CsvWriter *c = CsvWriterOpenSpecifyTerminate(w, false);
+        CsvWriterField(c, "a");
+        CsvWriterField(c, "b");
+        CsvWriterField(c, "c");
+        CsvWriterClose(c);
+
+        char *result_string = StringWriterClose(w);
+        assert_string_equal(result_string, "a,b,c");
+        free(result_string);
+    }
+    {
+        Writer *w = StringWriter();
+
+        CsvWriter *c = CsvWriterOpenSpecifyTerminate(w, false);
+        CsvWriterField(c, "a");
+        CsvWriterField(c, "b");
+        CsvWriterField(c, "c");
+        CsvWriterNewRecord(c);
+        CsvWriterField(c, "d");
+        CsvWriterField(c, "e");
+        CsvWriterField(c, "f");
+        CsvWriterClose(c);
+
+        char *result_string = StringWriterClose(w);
+        assert_string_equal(result_string, "a,b,c\r\nd,e,f");
+        free(result_string);
+    }
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -112,6 +170,8 @@ int main()
         unit_test(test_empty_record),
         unit_test(test_empty_last_record),
         unit_test(test_escape),
+        unit_test(test_terminate),
+        unit_test(test_no_terminate),
     };
 
     return run_tests(tests);


### PR DESCRIPTION
Useful for writing "single line csv", for use in reporting protocol.