### PR TITLE
Log messages about broken Mustache templates are now errors

### DIFF
--- a/libutils/mustache.c
+++ b/libutils/mustache.c
@@ -274,7 +274,7 @@ static Mustache NextTag(const char *input,
         const char *escape_end = strstr(ret.content, extra_end);
         if (!escape_end || strncmp(escape_end + 1, delim_end, delim_end_len) != 0)
         {
-            Log(LOG_LEVEL_WARNING, "Broken mustache template, couldn't find end tag for quoted begin tag at '%20s'...", input);
+            Log(LOG_LEVEL_ERR, "Broken mustache template, couldn't find end tag for quoted begin tag at '%20s'...", input);
             ret.type = TAG_TYPE_ERR;
             return ret;
         }
@@ -287,7 +287,7 @@ static Mustache NextTag(const char *input,
         ret.end = strstr(ret.content, delim_end);
         if (!ret.end)
         {
-            Log(LOG_LEVEL_WARNING, "Broken Mustache template, could not find end delimiter after reading start delimiter at '%20s'...", input);
+            Log(LOG_LEVEL_ERR, "Broken Mustache template, could not find end delimiter after reading start delimiter at '%20s'...", input);
             ret.type = TAG_TYPE_ERR;
             return ret;
         }


### PR DESCRIPTION
Previously, they were warnings.

According to core/CONTRIBUTING.md:

* `LOG_LEVEL_ERR`: Promise failed or other errors that are definitely
  considered bad / not normal.
* `LOG_LEVEL_WARNING`: Something unusual happened that the user should
  investigate. Should be severe enough to warrant investigating further,
  but not as severe as a definitive error/bug.

I would argue that if you have a broken template, that definitely
warrants an error. It means there is a bug in your template, or
whatever is generating the template. Looking at `git blame` this
has been a warning since mustache was introduced, and there is no
specific reasoning behind it.