### PR TITLE
Improved support for commands in help outputs and man pages

### DIFF
--- a/libutils/man.h
+++ b/libutils/man.h
@@ -30,7 +30,8 @@
 
 void ManPageWrite(Writer *out, const char *program, time_t last_modified,
                   const char *short_description, const char *long_description,
-                  const struct option options[],
-                  const char *const option_hints[], bool accepts_file_argument);
+                  const struct option options[], const char *const option_hints[],
+                  const Description *commands, bool command_first,
+                  bool accepts_file_argument);
 
 #endif

--- a/libutils/writer.c
+++ b/libutils/writer.c
@@ -318,13 +318,19 @@ static void WriterWriteCommands(Writer *w, const Description *commands)
 
 void WriterWriteHelp(Writer *w, const char *component,
                      const struct option options[], const char *const hints[],
-                     bool accepts_file_argument, const Description *commands)
+                     const Description *commands, bool command_first,
+                     bool accepts_file_argument)
 {
-    WriterWriteF(w, "Usage: %s [OPTIONS] %s%s\n", component,
-                 commands ? "command " : "",
+    WriterWriteF(w, "Usage: %s%s [OPTIONS]%s%s\n", component,
+                 (commands && command_first) ? " COMMAND" : "",
+                 (commands && !command_first) ? " COMMAND" : "",
                  accepts_file_argument ? " [FILE]" : "");
+    if ((commands != NULL) && command_first)
+    {
+        WriterWriteCommands(w, commands);
+    }
     WriterWriteOptions(w, options, hints);
-    if (commands != NULL)
+    if ((commands != NULL) && !command_first)
     {
         WriterWriteCommands(w, commands);
     }

--- a/libutils/writer.h
+++ b/libutils/writer.h
@@ -64,15 +64,16 @@ FILE *FileWriterDetach(Writer *writer);
 /* Commonly used on a FileWriter(stdout), ignoring return; so don't
  * try to warn on unused result ! */
 
- typedef struct
- {
-     const char *name;
-     const char *description;
-     const char *usage;
- } Description;
+typedef struct
+{
+    const char *name;
+    const char *description;
+    const char *usage;
+} Description;
 
- void WriterWriteHelp(Writer *w, const char *comp,
-                      const struct option options[], const char *const hints[],
-                      bool accepts_file_argument, const Description *commands);
+void WriterWriteHelp(Writer *w, const char *component,
+                     const struct option options[], const char *const hints[],
+                     const Description *commands, bool command_first,
+                     bool accepts_file_argument);
 
 #endif


### PR DESCRIPTION
In many cases it's more natural to use
  some-utility COMMAND OPTIONS
than
  some-utility OPTIONS COMMAND.

For such cases, we want to adapt the --help/-h output.

Ticket: CFE-3272
Changelog: None