### PR TITLE
Add a function for checking whether Log() would log a message

### DIFF
--- a/libutils/logging.h
+++ b/libutils/logging.h
@@ -94,6 +94,11 @@ bool LoggingFormatTimestamp(char dest[64], size_t n, struct tm *timestamp);
 LoggingContext *GetCurrentThreadContext(void);
 void LoggingFreeCurrentThreadContext(void);
 
+/**
+ * Whether a message with level #level would be logged by Log() or not.
+ */
+bool WouldLog(LogLevel level);
+
 void Log(LogLevel level, const char *fmt, ...) FUNC_ATTR_PRINTF(2, 3);
 void LogDebug(enum LogModule mod, const char *fmt, ...) FUNC_ATTR_PRINTF(2, 3);
 void LogRaw(LogLevel level, const char *prefix, const void *buf, size_t buflen);


### PR DESCRIPTION
Log() does most of the heavy lifting of formatting the log
message like printf() only when the log level means the message
will actually be logged. But sometimes there is a lot of work
being done before Log() is even called. It is nice to have a
chance to tell if such work can be skipped because Log() would
just discard the result anyway.