### PR TITLE
compiler.h: remove duplicated macro

### DIFF
--- a/libutils/compiler.h
+++ b/libutils/compiler.h
@@ -68,14 +68,4 @@
  */
 #define UNUSED(x) (void)(x)
 
-/**
- * If you want a string literal version of a macro, useful in scanf formats:
- *
- * #define BUFSIZE 1024
- * MACRO_STRING(BUFSIZE) -> "BUFSIZE"
- * STRING(BUFSIZE) -> "1024"
- */
-#define STRING(X) MACRO_STRING(X)
-#define MACRO_STRING(X) #X
-
 #endif  /* CFENGINE_COMPILER_H */


### PR DESCRIPTION
This functionality is also implemented by macro TOSTRING at string_lib.h

Changelog: None
Ticket: None
Signed-off-by: Lluis Campos <lluis.campos@northern.tech>