### PR TITLE
compiler.h: move, rename and document TO_STRING macro

### DIFF
--- a/libutils/compiler.h
+++ b/libutils/compiler.h
@@ -68,4 +68,14 @@
  */
 #define UNUSED(x) (void)(x)
 
+
+/**
+ * If you want a string literal version of a macro, useful in scanf formats:
+ *
+ * #define BUFSIZE 1024
+ * TO_STRING(BUFSIZE) -> "1024"
+ */
+#define STRINGIFY__INTERNAL_MACRO(x) #x
+#define TO_STRING(x) STRINGIFY__INTERNAL_MACRO(x)
+
 #endif  /* CFENGINE_COMPILER_H */

--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -425,7 +425,7 @@ char *MapName(char *s)
     if (strlcpy(s, ret, MAX_FILENAME) >= MAX_FILENAME)
     {
         FatalError(ctx, "Expanded path (%s) is longer than MAX_FILENAME ("
-                   TOSTRING(MAX_FILENAME) ") characters",
+                   TO_STRING(MAX_FILENAME) ") characters",
                    ret);
     }
     free(ret);

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -58,9 +58,6 @@ typedef struct
 #define NULL_TO_EMPTY_STRING(string) (string? string : "")
 #endif
 
-#define STRINGIFY__INTERNAL_MACRO(x) #x
-#define TOSTRING(x) STRINGIFY__INTERNAL_MACRO(x)
-
 unsigned int StringHash        (const char *str, unsigned int seed);
 unsigned int StringHash_untyped(const void *str, unsigned int seed);
 

--- a/libutils/string_sequence.c
+++ b/libutils/string_sequence.c
@@ -152,7 +152,7 @@ bool SeqStringWrite(Seq *seq, Writer *w)
         const char *const s = SeqAt(seq, i);
         const unsigned long str_length = strlen(s);
         const size_t bytes_written = WriterWriteF(
-            w, "%-" TOSTRING(SEQ_PREFIX_LEN) "lu%s\n", str_length, s);
+            w, "%-" TO_STRING(SEQ_PREFIX_LEN) "lu%s\n", str_length, s);
         // TODO: Make WriterWriteF actually be able to propagate errors
         //       (return negative number on short writes).
         if (bytes_written == 0)


### PR DESCRIPTION
Makes more sense for this macro to live in compiler.h. Renamed to follow
coding standard.

Changelog: None
Ticket: None
Signed-off-by: Lluis Campos <lluis.campos@northern.tech>