### PR TITLE
misc files: Add explicit checks for NULL before pointer dereferences

### DIFF
--- a/libutils/buffer.c
+++ b/libutils/buffer.c
@@ -50,6 +50,7 @@ Buffer *BufferNew(void)
 
 static void ExpandIfNeeded(Buffer *buffer, unsigned int needed)
 {
+    assert(buffer != NULL);
     if (needed >= buffer->capacity)
     {
         size_t new_capacity = UpperPowerOfTwo(needed + 1);
@@ -68,7 +69,7 @@ Buffer* BufferNewFrom(const char *data, unsigned int length)
 
 void BufferDestroy(Buffer *buffer)
 {
-    if (buffer)
+    if (buffer != NULL)
     {
         free(buffer->buffer);
         free(buffer);
@@ -77,6 +78,7 @@ void BufferDestroy(Buffer *buffer)
 
 char *BufferClose(Buffer *buffer)
 {
+    assert(buffer != NULL);
     char *detached = buffer->buffer;
     free(buffer);
 
@@ -85,14 +87,14 @@ char *BufferClose(Buffer *buffer)
 
 Buffer *BufferCopy(const Buffer *source)
 {
-    assert(source);
+    assert(source != NULL);
     return BufferNewFrom(source->buffer, source->used);
 }
 
 int BufferCompare(const Buffer *buffer1, const Buffer *buffer2)
 {
-    assert(buffer1);
-    assert(buffer2);
+    assert(buffer1 != NULL);
+    assert(buffer2 != NULL);
 
     /*
      * Rules for comparison:
@@ -224,8 +226,8 @@ int BufferCompare(const Buffer *buffer1, const Buffer *buffer2)
 
 void BufferSet(Buffer *buffer, const char *bytes, unsigned int length)
 {
-    assert(buffer);
-    assert(bytes);
+    assert(buffer != NULL);
+    assert(bytes != NULL);
 
     BufferClear(buffer);
 
@@ -234,13 +236,15 @@ void BufferSet(Buffer *buffer, const char *bytes, unsigned int length)
 
 char *BufferGet(Buffer *buffer)
 {
-    assert(buffer);
+    assert(buffer != NULL);
     buffer->unsafe = true;
     return buffer->buffer;
 }
 
 void BufferAppendString(Buffer *buffer, const char *str)
 {
+    assert(buffer != NULL);
+
     size_t len = strlen(str);
     ExpandIfNeeded(buffer, buffer->used + len + 1);
     memcpy(buffer->buffer + buffer->used, str, len);
@@ -250,6 +254,8 @@ void BufferAppendString(Buffer *buffer, const char *str)
 
 void BufferTrimToMaxLength(Buffer *buffer, unsigned int max)
 {
+    assert(buffer != NULL);
+
     if (buffer->used > max)
     {
         buffer->used = max;
@@ -260,8 +266,8 @@ void BufferTrimToMaxLength(Buffer *buffer, unsigned int max)
 
 void BufferAppend(Buffer *buffer, const char *bytes, unsigned int length)
 {
-    assert(buffer);
-    assert(bytes);
+    assert(buffer != NULL);
+    assert(bytes != NULL);
 
     if (length == 0)
     {
@@ -290,6 +296,7 @@ void BufferAppend(Buffer *buffer, const char *bytes, unsigned int length)
 
 void BufferAppendChar(Buffer *buffer, char byte)
 {
+    assert(buffer != NULL);
     if (buffer->used < (buffer->capacity - 1))
     {
         buffer->buffer[buffer->used] = byte;
@@ -308,8 +315,8 @@ void BufferAppendChar(Buffer *buffer, char byte)
 
 void BufferAppendF(Buffer *buffer, const char *format, ...)
 {
-    assert(buffer);
-    assert(format);
+    assert(buffer != NULL);
+    assert(format != NULL);
 
     va_list ap;
     va_list aq;
@@ -338,8 +345,8 @@ void BufferAppendF(Buffer *buffer, const char *format, ...)
 
 int BufferPrintf(Buffer *buffer, const char *format, ...)
 {
-    assert(buffer);
-    assert(format);
+    assert(buffer != NULL);
+    assert(format != NULL);
     /*
      * We declare two lists, in case we need to reiterate over the list because the buffer was
      * too small.
@@ -382,8 +389,8 @@ int BufferPrintf(Buffer *buffer, const char *format, ...)
 // NB! Make sure to sanitize format if taken from user input
 int BufferVPrintf(Buffer *buffer, const char *format, va_list ap)
 {
-    assert(buffer);
-    assert(format);
+    assert(buffer != NULL);
+    assert(format != NULL);
     va_list aq;
     va_copy(aq, ap);
 
@@ -416,7 +423,7 @@ int BufferVPrintf(Buffer *buffer, const char *format, va_list ap)
 // returns NULL on success, otherwise an error string
 const char* BufferSearchAndReplace(Buffer *buffer, const char *pattern, const char *substitute, const char *options)
 {
-    assert(buffer);
+    assert(buffer != NULL);
     assert(pattern);
     assert(substitute);
     assert(options);
@@ -447,26 +454,26 @@ const char* BufferSearchAndReplace(Buffer *buffer, const char *pattern, const ch
 
 void BufferClear(Buffer *buffer)
 {
-    assert(buffer);
+    assert(buffer != NULL);
     buffer->used = 0;
     buffer->buffer[0] = '\0';
 }
 
 unsigned int BufferSize(const Buffer *buffer)
 {
-    assert(buffer);
-    return buffer ? buffer->used : 0;
+    assert(buffer != NULL);
+    return buffer != NULL ? buffer->used : 0;
 }
 
 const char *BufferData(const Buffer *buffer)
 {
-    assert(buffer);
-    return buffer ? buffer->buffer : NULL;
+    assert(buffer != NULL);
+    return buffer != NULL ? buffer->buffer : NULL;
 }
 
 void BufferCanonify(Buffer *buffer)
 {
-    assert(buffer);
+    assert(buffer != NULL);
     if (buffer         != NULL &&
         buffer->buffer != NULL)
     {
@@ -476,13 +483,13 @@ void BufferCanonify(Buffer *buffer)
 
 BufferBehavior BufferMode(const Buffer *buffer)
 {
-    assert(buffer);
-    return buffer ? buffer->mode : BUFFER_BEHAVIOR_BYTEARRAY;
+    assert(buffer != NULL);
+    return buffer != NULL ? buffer->mode : BUFFER_BEHAVIOR_BYTEARRAY;
 }
 
 void BufferSetMode(Buffer *buffer, BufferBehavior mode)
 {
-    assert(buffer);
+    assert(buffer != NULL);
     assert(mode == BUFFER_BEHAVIOR_CSTRING || mode == BUFFER_BEHAVIOR_BYTEARRAY);
     /*
      * If we switch from BYTEARRAY mode to CSTRING then we need to adjust the
@@ -504,7 +511,7 @@ void BufferSetMode(Buffer *buffer, BufferBehavior mode)
 
 Buffer* BufferFilter(Buffer *buffer, BufferFilterFn filter, const bool invert)
 {
-    assert(buffer);
+    assert(buffer != NULL);
 
     Buffer *filtered = BufferNew();
     for (unsigned int i = 0; i < buffer->used; ++i)
@@ -526,7 +533,7 @@ Buffer* BufferFilter(Buffer *buffer, BufferFilterFn filter, const bool invert)
 
 void BufferRewrite(Buffer *buffer, BufferFilterFn filter, const bool invert)
 {
-    assert(buffer);
+    assert(buffer != NULL);
 
     Buffer *rewrite = BufferFilter(buffer, filter, invert);
     BufferSet(buffer, BufferData(rewrite), BufferSize(rewrite));
@@ -535,6 +542,6 @@ void BufferRewrite(Buffer *buffer, BufferFilterFn filter, const bool invert)
 
 unsigned BufferCapacity(const Buffer *buffer)
 {
-    assert(buffer);
-    return buffer ? buffer->capacity : 0;
+    assert(buffer != NULL);
+    return buffer != NULL ? buffer->capacity : 0;
 }

--- a/libutils/csv_writer.c
+++ b/libutils/csv_writer.c
@@ -59,6 +59,8 @@ CsvWriter *CsvWriterOpen(Writer *w)
 
 void CsvWriterField(CsvWriter * csvw, const char *str)
 {
+    assert(csvw != NULL);
+
     if (csvw->beginning_of_line)
     {
         csvw->beginning_of_line = false;
@@ -93,6 +95,8 @@ void CsvWriterFieldF(CsvWriter * csvw, const char *fmt, ...)
 
 void CsvWriterNewRecord(CsvWriter * csvw)
 {
+    assert(csvw != NULL);
+
     WriterWrite(csvw->w, "\r\n");
     csvw->beginning_of_line = true;
 }
@@ -145,5 +149,6 @@ static void WriteCsvEscapedString(Writer *w, const char *s)
 
 Writer *CsvWriterGetWriter(CsvWriter *csvw)
 {
+    assert(csvw != NULL);
     return csvw->w;
 }

--- a/libutils/json-yaml.c
+++ b/libutils/json-yaml.c
@@ -48,7 +48,7 @@ JsonParseError JsonParseYamlFile(const char *path, size_t size_max, JsonElement 
 
 static JsonElement* JsonParseYamlScalarValue(yaml_event_t *event)
 {
-    assert(event);
+    assert(event != NULL);
     assert(event->type == YAML_SCALAR_EVENT);
 
     const char *tag = (const char *) event->data.scalar.tag;

--- a/libutils/list.c
+++ b/libutils/list.c
@@ -77,6 +77,8 @@ struct ListIterator {
  */
 static void ListDetach(List *list)
 {
+    assert(list != NULL);
+
     int shared = RefCountIsShared(list->ref_count);
     if (shared)
     {
@@ -179,7 +181,9 @@ int ListDestroy(List **list)
         for (node = (*list)->first; node; node = p)
         {
             if ((*list)->destroy)
+            {
                 (*list)->destroy(node->payload);
+            }
             p = node->next;
             free(node);
         }
@@ -192,8 +196,10 @@ int ListDestroy(List **list)
 
 int ListCopy(List *origin, List **destination)
 {
-    if (!origin || !destination)
+    if (origin == NULL || destination == NULL)
+    {
         return -1;
+    }
     /*
      * The first thing we check is the presence of a copy function.
      * Without that function we need to abort the operation.
@@ -224,7 +230,7 @@ int ListCopy(List *origin, List **destination)
 int ListPrepend(List *list, void *payload)
 {
     ListNode *node = NULL;
-    if (!list)
+    if (list == NULL)
     {
         return -1;
     }
@@ -253,7 +259,7 @@ int ListPrepend(List *list, void *payload)
 int ListAppend(List *list, void *payload)
 {
     ListNode *node = NULL;
-    if (!list)
+    if (list == NULL)
     {
         return -1;
     }
@@ -287,7 +293,7 @@ int ListAppend(List *list, void *payload)
  */
 static int ListFindNode(List *list, void *payload)
 {
-    if (!list)
+    if (list == NULL)
     {
         return -1;
     }
@@ -296,7 +302,9 @@ static int ListFindNode(List *list, void *payload)
     for (node = list->list; node; node = node->next)
     {
         if (!node->payload)
+        {
             continue;
+        }
         if (list->compare)
         {
             if (!list->compare(node->payload, payload))
@@ -318,14 +326,18 @@ static int ListFindNode(List *list, void *payload)
 }
 static void ListUpdateListState(List *list)
 {
+    assert(list != NULL);
     list->node_count--;
     ChangeListState(list);
 }
 
 int ListRemove(List *list, void *payload)
 {
-    if (!list || !payload)
+    if (list == NULL || payload == NULL)
+    {
         return -1;
+    }
+
     ListNode *node = NULL;
     /*
      * This is a complicated matter. We could detach the list before
@@ -336,7 +348,9 @@ int ListRemove(List *list, void *payload)
      */
     int found = ListFindNode(list, payload);
     if (!found)
+    {
         return -1;
+    }
     found = 0;
     ListDetach(list);
     node = NULL;
@@ -445,7 +459,7 @@ int ListRemove(List *list, void *payload)
 // Number of elements on the list
 int ListCount(const List *list)
 {
-    return list ? list->node_count : -1;
+    return list != NULL ? list->node_count : -1;
 }
 
 /*
@@ -453,7 +467,7 @@ int ListCount(const List *list)
  */
 ListIterator *ListIteratorGet(const List *list)
 {
-    if (!list)
+    if (list == NULL)
     {
         return NULL;
     }
@@ -485,7 +499,7 @@ int ListIteratorDestroy(ListIterator **iterator)
 
 int ListIteratorFirst(ListIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
     {
         return -1;
     }
@@ -500,7 +514,7 @@ int ListIteratorFirst(ListIterator *iterator)
 
 int ListIteratorLast(ListIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
     {
         return -1;
     }
@@ -515,7 +529,7 @@ int ListIteratorLast(ListIterator *iterator)
 
 int ListIteratorNext(ListIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
     {
         return -1;
     }
@@ -538,7 +552,7 @@ int ListIteratorNext(ListIterator *iterator)
 
 int ListIteratorPrevious(ListIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
     {
         return -1;
     }
@@ -561,7 +575,7 @@ int ListIteratorPrevious(ListIterator *iterator)
 
 void *ListIteratorData(const ListIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
     {
         return NULL;
     }
@@ -575,7 +589,7 @@ void *ListIteratorData(const ListIterator *iterator)
 
 bool ListIteratorHasNext(const ListIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
     {
         return false;
     }
@@ -593,7 +607,7 @@ bool ListIteratorHasNext(const ListIterator *iterator)
 
 bool ListIteratorHasPrevious(const ListIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
     {
         return false;
     }
@@ -614,7 +628,7 @@ bool ListIteratorHasPrevious(const ListIterator *iterator)
  */
 ListMutableIterator *ListMutableIteratorGet(List *list)
 {
-    if (!list)
+    if (list == NULL)
     {
         return NULL;
     }
@@ -649,87 +663,122 @@ int ListMutableIteratorRelease(ListMutableIterator **iterator)
 
 int ListMutableIteratorFirst(ListMutableIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
+    {
         return -1;
+    }
     if (IsMutableIteratorValid(iterator))
+    {
         return -1;
+    }
     iterator->current = iterator->origin->first;
     return 0;
 }
 
 int ListMutableIteratorLast(ListMutableIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
+    {
         return -1;
+    }
     if (IsMutableIteratorValid(iterator))
+    {
         return -1;
+    }
     iterator->current = iterator->origin->last;
     return 0;
 }
 
 int ListMutableIteratorNext(ListMutableIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
+    {
         return -1;
+    }
     if (IsMutableIteratorValid(iterator))
+    {
         return -1;
+    }
     if (!iterator->current->next)
+    {
         return -1;
+    }
     iterator->current = iterator->current->next;
     return 0;
 }
 
 int ListMutableIteratorPrevious(ListMutableIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
+    {
         return -1;
+    }
     if (IsMutableIteratorValid(iterator))
+    {
         return -1;
+    }
     if (!iterator->current->previous)
+    {
         return -1;
+    }
     iterator->current = iterator->current->previous;
     return 0;
 }
 
 void *ListMutableIteratorData(const ListMutableIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
+    {
         return NULL;
+    }
     if (IsMutableIteratorValid(iterator))
+    {
         return NULL;
+    }
     return (void *)iterator->current->payload;
 }
 
 int ListMutableIteratorRemove(ListMutableIterator *iterator)
 {
-    if (!iterator)
+    if (iterator == NULL)
+    {
         return -1;
+    }
     if (IsMutableIteratorValid(iterator))
+    {
         return -1;
+    }
     ListDetach(iterator->origin);
     /*
      * Removing an element is not as simple as it sounds. We need to inform the list
      * and make sure we move out of the way.
      */
     ListNode *node = NULL;
-    if (iterator->current->next) {
+    if (iterator->current->next)
+    {
         /*
          * We are not the last element, therefore we proceed as normal.
          */
         node = iterator->current->next;
-    } else {
+    }
+    else
+    {
         /*
          * We might be the last element or the only element on the list.
          * If we are the only element we do not destroy the element otherwise the iterator
          * would become invalid.
          */
-        if (iterator->current->previous) {
+        if (iterator->current->previous)
+        {
             /*
              * last element
              */
             node = iterator->current->previous;
-        } else
+        }
+        else
+        {
             return -1;
+        }
     }
     /*
      * Now, remove the node from the list and delete it.
@@ -769,20 +818,27 @@ int ListMutableIteratorRemove(ListMutableIterator *iterator)
 
 int ListMutableIteratorPrepend(ListMutableIterator *iterator, void *payload)
 {
-    if (!iterator)
+    if (iterator == NULL)
+    {
         return -1;
+    }
     if (IsMutableIteratorValid(iterator))
+    {
         return -1;
+    }
     ListNode *node = NULL;
     node = (ListNode *)xmalloc(sizeof(ListNode));
     ListDetach(iterator->origin);
     node->payload = payload;
-    if (iterator->current->previous) {
+    if (iterator->current->previous)
+    {
         node->previous = iterator->current->previous;
         node->next = iterator->current;
         iterator->current->previous->next = node;
         iterator->current->previous = node;
-    } else {
+    }
+    else
+    {
         // First element
         node->previous = NULL;
         node->next = iterator->current;
@@ -796,10 +852,14 @@ int ListMutableIteratorPrepend(ListMutableIterator *iterator, void *payload)
 
 int ListMutableIteratorAppend(ListMutableIterator *iterator, void *payload)
 {
-    if (!iterator)
+    if (iterator == NULL)
+    {
         return -1;
+    }
     if (IsMutableIteratorValid(iterator))
+    {
         return -1;
+    }
     ListNode *node = NULL;
     node = (ListNode *)xmalloc(sizeof(ListNode));
     ListDetach(iterator->origin);
@@ -810,7 +870,9 @@ int ListMutableIteratorAppend(ListMutableIterator *iterator, void *payload)
         node->previous = iterator->current;
         iterator->current->next->previous = node;
         iterator->current->next = node;
-    } else {
+    }
+    else
+    {
         // Last element
         node->next = NULL;
         node->previous = iterator->current;
@@ -823,10 +885,10 @@ int ListMutableIteratorAppend(ListMutableIterator *iterator, void *payload)
 
 bool ListMutableIteratorHasNext(const ListMutableIterator *iterator)
 {
-    return iterator && iterator->current->next;
+    return iterator != NULL && iterator->current->next;
 }
 
 bool ListMutableIteratorHasPrevious(const ListMutableIterator *iterator)
 {
-    return iterator && iterator->current->previous;
+    return iterator != NULL && iterator->current->previous;
 }

--- a/libutils/sequence.c
+++ b/libutils/sequence.c
@@ -47,6 +47,7 @@ Seq *SeqNew(size_t initialCapacity, void (ItemDestroy) (void *item))
 
 static void DestroyRange(Seq *seq, size_t start, size_t end)
 {
+    assert(seq != NULL);
     if (seq->ItemDestroy)
     {
         for (size_t i = start; i <= end; i++)
@@ -58,16 +59,19 @@ static void DestroyRange(Seq *seq, size_t start, size_t end)
 
 void SeqDestroy(Seq *seq)
 {
-    if (seq && seq->length > 0)
+    if (seq != NULL)
     {
-        DestroyRange(seq, 0, seq->length - 1);
+        if (seq->length > 0)
+        {
+            DestroyRange(seq, 0, seq->length - 1);
+        }
+        SeqSoftDestroy(seq);
     }
-    SeqSoftDestroy(seq);
 }
 
 void SeqSoftDestroy(Seq *seq)
 {
-    if (seq)
+    if (seq != NULL)
     {
         free(seq->data);
         free(seq);
@@ -76,6 +80,7 @@ void SeqSoftDestroy(Seq *seq)
 
 static void ExpandIfNeccessary(Seq *seq)
 {
+    assert(seq != NULL);
     assert(seq->length <= seq->capacity);
 
     if (seq->length == seq->capacity)
@@ -87,6 +92,7 @@ static void ExpandIfNeccessary(Seq *seq)
 
 void SeqSet(Seq *seq, size_t index, void *item)
 {
+    assert(seq != NULL);
     assert(index < SeqLength(seq));
     if (seq->ItemDestroy)
     {
@@ -97,6 +103,7 @@ void SeqSet(Seq *seq, size_t index, void *item)
 
 void SeqAppend(Seq *seq, void *item)
 {
+    assert(seq != NULL);
     ExpandIfNeccessary(seq);
 
     seq->data[seq->length] = item;
@@ -105,6 +112,7 @@ void SeqAppend(Seq *seq, void *item)
 
 void SeqAppendOnce(Seq *seq, void *item, SeqItemComparator Compare)
 {
+    assert(seq != NULL);
     if (SeqLookup(seq, item, Compare) == NULL)
     {
         SeqAppend(seq, item);
@@ -129,7 +137,7 @@ void SeqAppendSeq(Seq *seq, const Seq *items)
 
 void SeqRemoveRange(Seq *seq, size_t start, size_t end)
 {
-    assert(seq);
+    assert(seq != NULL);
     assert(end < seq->length);
     assert(start <= end);
 
@@ -152,6 +160,7 @@ void SeqRemove(Seq *seq, size_t index)
 
 void *SeqLookup(Seq *seq, const void *key, SeqItemComparator Compare)
 {
+    assert(seq != NULL);
     for (size_t i = 0; i < seq->length; i++)
     {
         if (Compare(key, seq->data[i], NULL) == 0)
@@ -165,6 +174,7 @@ void *SeqLookup(Seq *seq, const void *key, SeqItemComparator Compare)
 
 void *SeqBinaryLookup(Seq *seq, const void *key, SeqItemComparator Compare)
 {
+    assert(seq != NULL);
     ssize_t index = SeqBinaryIndexOf(seq, key, Compare);
     if (index == -1)
     {
@@ -178,6 +188,7 @@ void *SeqBinaryLookup(Seq *seq, const void *key, SeqItemComparator Compare)
 
 ssize_t SeqIndexOf(Seq *seq, const void *key, SeqItemComparator Compare)
 {
+    assert(seq != NULL);
     for (size_t i = 0; i < seq->length; i++)
     {
         if (Compare(key, seq->data[i], NULL) == 0)
@@ -191,6 +202,7 @@ ssize_t SeqIndexOf(Seq *seq, const void *key, SeqItemComparator Compare)
 
 ssize_t SeqBinaryIndexOf(Seq *seq, const void *key, SeqItemComparator Compare)
 {
+    assert(seq != NULL);
     if (seq->length == 0)
     {
         return -1;
@@ -284,7 +296,7 @@ Seq *SeqSoftSort(const Seq *seq, SeqItemComparator compare, void *user_data)
 
 void SeqSoftRemoveRange(Seq *seq, size_t start, size_t end)
 {
-    assert(seq);
+    assert(seq != NULL);
     assert(end < seq->length);
     assert(start <= end);
 
@@ -313,6 +325,7 @@ void SeqSoftRemove(Seq *seq, size_t index)
 
 void SeqReverse(Seq *seq)
 {
+    assert(seq != NULL);
     for (size_t i = 0; i < (seq->length / 2); i++)
     {
         Swap(&seq->data[i], &seq->data[seq->length - 1 - i]);
@@ -321,6 +334,7 @@ void SeqReverse(Seq *seq)
 
 Seq *SeqSplit(Seq *seq, size_t index)
 {
+    assert(seq != NULL);
     size_t length = SeqLength(seq);
     assert(index <= length); // index > length is invalid
     if (index >= length)
@@ -338,12 +352,13 @@ Seq *SeqSplit(Seq *seq, size_t index)
 
 size_t SeqLength(const Seq *seq)
 {
-    assert(seq);
+    assert(seq != NULL);
     return seq->length;
 }
 
 void SeqShuffle(Seq *seq, unsigned int seed)
 {
+    assert(seq != NULL);
     if (SeqLength(seq) == 0)
     {
         return;
@@ -366,7 +381,7 @@ void SeqShuffle(Seq *seq, unsigned int seed)
 
 Seq *SeqGetRange(const Seq *seq, size_t start, size_t end)
 {
-    assert (seq);
+    assert(seq != NULL);
 
     if ((start > end) || (start >= seq->length) || (end >= seq->length))
     {
@@ -390,26 +405,27 @@ void *const *SeqGetData(const Seq *seq)
     return seq->data;
 }
 
-void SeqRemoveNulls(Seq *s)
+void SeqRemoveNulls(Seq *seq)
 {
-    int length = SeqLength(s);
+    assert(seq != NULL);
+    int length = SeqLength(seq);
     int from = 0;
     int to = 0;
     while (from < length)
     {
-        if (s->data[from] == NULL)
+        if (seq->data[from] == NULL)
         {
             ++from; // Skip NULL elements
         }
         else
         {
             // Copy elements in place, DON'T use SeqSet, which will free()
-            s->data[to] = s->data[from];
+            seq->data[to] = seq->data[from];
             ++from;
             ++to;
         }
     }
-    s->length = to;
+    seq->length = to;
 }
 
 Seq *SeqFromArgv(int argc, const char *const *const argv)

--- a/libutils/sequence.h
+++ b/libutils/sequence.h
@@ -252,7 +252,7 @@ Seq *SeqGetRange(const Seq *seq, size_t start, size_t end);
  */
 void *const *SeqGetData(const Seq *seq);
 
-void SeqRemoveNulls(Seq *s);
+void SeqRemoveNulls(Seq *seq);
 
 Seq *SeqFromArgv(int argc, const char *const *argv);
 


### PR DESCRIPTION
Gets the rid of a bunch of LGTM alerts. Minor style and consistency
fixes along the way.