### PR TITLE
Revert "Added CF_SYSTEM_GROUP based on ifdefs"

### DIFF
--- a/libutils/definitions.h
+++ b/libutils/definitions.h
@@ -53,14 +53,4 @@
 // 0644 - World readable
 #define CF_PERMS_SHARED   CF_PERMS_DEFAULT | S_IRGRP | S_IROTH
 
-/*****************************************************************************
- *                       File Ownership                                         *
- *****************************************************************************/
-#ifdef __FreeBSD__
-#  define CF_SYSTEM_GROUP "wheel"
-#elif defined(__Solaris__)
-#  define CF_SYSTEM_GROUP "sys"
-#else
-#  define CF_SYSTEM_GROUP "root"
-#endif
 #endif // CFENGINE_DEFINITIONS_H


### PR DESCRIPTION
This reverts commit a38d6130c34656ca235b3d9aebd08209dde1afcc.

The logic for group ownership is moved/refined in masterfiles instead.
This information in libntech is not very reliable so should not be included.
Ideally we would examine each system at run-time to determine the
default group for root. For now our "guesses" are in masterfiles https://github.com/cfengine/masterfiles/pull/1768

Conflicts:
	libutils/definitions.h