### PR TITLE
Renamed StringSafeEqual() to StringEqual()

### DIFF
--- a/libutils/json-utils.c
+++ b/libutils/json-utils.c
@@ -384,19 +384,19 @@ JsonElement *JsonReadDataFile(const char *log_identifier, const char *input_path
 DataFileType GetDataFileTypeFromString(const char *const requested_mode)
 {
     DataFileType type = DATAFILETYPE_UNKNOWN;
-    if (StringSafeEqual_IgnoreCase(requested_mode, "yaml"))
+    if (StringEqual_IgnoreCase(requested_mode, "yaml"))
     {
         type = DATAFILETYPE_YAML;
     }
-    else if (StringSafeEqual_IgnoreCase(requested_mode, "csv"))
+    else if (StringEqual_IgnoreCase(requested_mode, "csv"))
     {
         type = DATAFILETYPE_CSV;
     }
-    else if (StringSafeEqual_IgnoreCase(requested_mode, "env"))
+    else if (StringEqual_IgnoreCase(requested_mode, "env"))
     {
         type = DATAFILETYPE_ENV;
     }
-    else if (StringSafeEqual_IgnoreCase(requested_mode, "json"))
+    else if (StringEqual_IgnoreCase(requested_mode, "json"))
     {
         type = DATAFILETYPE_JSON;
     }

--- a/libutils/json.c
+++ b/libutils/json.c
@@ -742,7 +742,7 @@ bool JsonPrimitiveGetAsBool(const JsonElement *const primitive)
     assert(primitive->type == JSON_ELEMENT_TYPE_PRIMITIVE);
     assert(primitive->primitive.type == JSON_PRIMITIVE_TYPE_BOOL);
 
-    return StringSafeEqual(JSON_TRUE, primitive->primitive.value);
+    return StringEqual(JSON_TRUE, primitive->primitive.value);
 }
 
 long JsonPrimitiveGetAsInteger(const JsonElement *const primitive)

--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -143,31 +143,31 @@ LogLevel LogLevelFromString(const char *const level)
     {
         return LOG_LEVEL_NOTHING;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "CRITICAL", len))
+    if (StringEqualN_IgnoreCase(level, "CRITICAL", len))
     {
         return LOG_LEVEL_CRIT;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "errors", len))
+    if (StringEqualN_IgnoreCase(level, "errors", len))
     {
         return LOG_LEVEL_ERR;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "warnings", len))
+    if (StringEqualN_IgnoreCase(level, "warnings", len))
     {
         return LOG_LEVEL_WARNING;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "notices", len))
+    if (StringEqualN_IgnoreCase(level, "notices", len))
     {
         return LOG_LEVEL_NOTICE;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "information", len))
+    if (StringEqualN_IgnoreCase(level, "information", len))
     {
         return LOG_LEVEL_INFO;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "verbose", len))
+    if (StringEqualN_IgnoreCase(level, "verbose", len))
     {
         return LOG_LEVEL_VERBOSE;
     }
-    if (StringSafeEqualN_IgnoreCase(level, "debug", len))
+    if (StringEqualN_IgnoreCase(level, "debug", len))
     {
         return LOG_LEVEL_DEBUG;
     }

--- a/libutils/map.c
+++ b/libutils/map.c
@@ -354,6 +354,6 @@ MapKeyValue *MapIteratorNext(MapIterator *i)
 
 TYPED_MAP_DEFINE(String, char *, char *,
                  StringHash_untyped,
-                 StringSafeEqual_untyped,
+                 StringEqual_untyped,
                  &free,
                  &free)

--- a/libutils/mustache.c
+++ b/libutils/mustache.c
@@ -568,8 +568,8 @@ static bool IsKeyExtensionVar(TagType tag_type, const char *tag_start,
         /* the special case of unescaped form using {{{@}}} iff "{{" and "}}" are
          * used as delimiters */
         if ((delim_start_len == 2) && (delim_end_len == 2) &&
-            StringSafeEqual(delim_start, "{{") &&
-            StringSafeEqual(delim_end, "}}") &&
+            StringEqual(delim_start, "{{") &&
+            StringEqual(delim_end, "}}") &&
             StringStartsWith(tag_start, "{{{@}}}"))
         {
             return true;

--- a/libutils/set.c
+++ b/libutils/set.c
@@ -31,7 +31,7 @@
 #include <buffer.h>
 
 TYPED_SET_DEFINE(String, char *,
-                 StringHash_untyped, StringSafeEqual_untyped, free)
+                 StringHash_untyped, StringEqual_untyped, free)
 
 Set *SetNew(MapHashFn element_hash_fn,
             MapKeyEqualFn element_equal_fn,

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -252,12 +252,12 @@ int StringSafeCompareN(const char *const a, const char *const b, const size_t n)
     return NullCompare(a, b);
 }
 
-bool StringSafeEqual(const char *const a, const char *const b)
+bool StringEqual(const char *const a, const char *const b)
 {
     return (StringSafeCompare(a, b) == 0);
 }
 
-bool StringSafeEqualN(const char *const a, const char *const b, const size_t n)
+bool StringEqualN(const char *const a, const char *const b, const size_t n)
 {
     return (StringSafeCompareN(a, b, n) == 0);
 }
@@ -292,19 +292,19 @@ int StringSafeCompareN_IgnoreCase(const char *const a, const char *const b, cons
     return NullCompare(a, b);
 }
 
-bool StringSafeEqual_IgnoreCase(const char *const a, const char *const b)
+bool StringEqual_IgnoreCase(const char *const a, const char *const b)
 {
     return (StringSafeCompare_IgnoreCase(a, b) == 0);
 }
 
-bool StringSafeEqualN_IgnoreCase(const char *const a, const char *const b, const size_t n)
+bool StringEqualN_IgnoreCase(const char *const a, const char *const b, const size_t n)
 {
     return (StringSafeCompareN_IgnoreCase(a, b, n) == 0);
 }
 
-bool StringSafeEqual_untyped(const void *a, const void *b)
+bool StringEqual_untyped(const void *a, const void *b)
 {
-    return StringSafeEqual(a, b);
+    return StringEqual(a, b);
 }
 
 /*********************************************************************/
@@ -1500,7 +1500,7 @@ bool StringMatchesOption(
     }
     else if (length == 2)
     {
-        return StringSafeEqual(supplied, shortopt);
+        return StringEqual(supplied, shortopt);
     }
-    return StringSafeEqualN_IgnoreCase(supplied, longopt, length);
+    return StringEqualN_IgnoreCase(supplied, longopt, length);
 }

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -110,18 +110,18 @@ char *SafeStringNDuplicate(const char *str, size_t size);
 int SafeStringLength(const char *str);
 
 int  StringSafeCompare(const char *a, const char *b);
-bool StringSafeEqual  (const char *a, const char *b);
+bool StringEqual  (const char *a, const char *b);
 
 int  StringSafeCompareN(const char *a, const char *b, size_t n);
-bool StringSafeEqualN  (const char *a, const char *b, size_t n);
+bool StringEqualN  (const char *a, const char *b, size_t n);
 
 int  StringSafeCompare_IgnoreCase(const char *a, const char *b);
-bool StringSafeEqual_IgnoreCase  (const char *a, const char *b);
+bool StringEqual_IgnoreCase  (const char *a, const char *b);
 
 int  StringSafeCompareN_IgnoreCase(const char *a, const char *b, size_t n);
-bool StringSafeEqualN_IgnoreCase  (const char *a, const char *b, size_t n);
+bool StringEqualN_IgnoreCase  (const char *a, const char *b, size_t n);
 
-bool StringSafeEqual_untyped(const void *a, const void *b);
+bool StringEqual_untyped(const void *a, const void *b);
 
 char *StringConcatenate(size_t count, const char *first, ...);
 char *StringSubstring(const char *source, size_t source_len, int start, int len);

--- a/libutils/string_sequence.c
+++ b/libutils/string_sequence.c
@@ -62,7 +62,7 @@ bool SeqStringContains(const Seq *const seq, const char *const str)
     size_t length = SeqLength(seq);
     for (int i = 0; i < length; ++i)
     {
-        if (StringSafeEqual(str, SeqAt(seq, i)))
+        if (StringEqual(str, SeqAt(seq, i)))
         {
             return true;
         }

--- a/tests/unit/hash_test.c
+++ b/tests/unit/hash_test.c
@@ -247,18 +247,18 @@ static void test_StringCopyTruncateAndHashIfNecessary(void)
     const char *too_long = "The quick brown fox jumps over the lazy dog";
     ret = StringCopyTruncateAndHashIfNecessary(too_long, buf, 40);
     assert_int_equal(ret, 40);
-    assert_false(StringSafeEqual(too_long, buf));
+    assert_false(StringEqual(too_long, buf));
     assert_true(strlen(too_long) != strlen(buf));
     assert_int_equal(strlen(buf), 39);
-    assert_true(StringSafeEqual(buf, "Th#MD5=9e107d9d372bb6826bd81d3542a419d6"));
+    assert_true(StringEqual(buf, "Th#MD5=9e107d9d372bb6826bd81d3542a419d6"));
 
     ret = StringCopyTruncateAndHashIfNecessary(too_long, buf, 39);
     assert_int_equal(ret, 39);
-    assert_true(StringSafeEqual(buf, "T#MD5=9e107d9d372bb6826bd81d3542a419d6"));
+    assert_true(StringEqual(buf, "T#MD5=9e107d9d372bb6826bd81d3542a419d6"));
 
     ret = StringCopyTruncateAndHashIfNecessary(too_long, buf, 38);
     assert_int_equal(ret, 38);
-    assert_true(StringSafeEqual(buf, "#MD5=9e107d9d372bb6826bd81d3542a419d6"));
+    assert_true(StringEqual(buf, "#MD5=9e107d9d372bb6826bd81d3542a419d6"));
 }
 
 /*

--- a/tests/unit/map_test.c
+++ b/tests/unit/map_test.c
@@ -28,13 +28,13 @@ static void test_new_destroy(void)
 static void test_new_hashmap_bad_size(void)
 {
     /* too small */
-    HashMap *hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                                   free, free, MIN_HASHMAP_BUCKETS >> 1);
     assert_int_equal(hashmap->size, MIN_HASHMAP_BUCKETS);
     HashMapDestroy(hashmap);
 
     /* not a pow2 */
-    hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                          free, free, 123);
     assert_int_equal(hashmap->size, 128);
     HashMapDestroy(hashmap);
@@ -101,7 +101,7 @@ static void test_insert_jumbo(void)
 
 static void test_remove(void)
 {
-    HashMap *hashmap = HashMapNew(ConstHash, StringSafeEqual_untyped, free, free,
+    HashMap *hashmap = HashMapNew(ConstHash, StringEqual_untyped, free, free,
                                   HASH_MAP_INIT_SIZE);
 
     HashMapInsert(hashmap, xstrdup("a"), xstrdup("b"));
@@ -159,7 +159,7 @@ static void assert_n_as_in_map(HashMap *hashmap, unsigned int i, bool in)
 static void test_grow(void)
 {
     unsigned int i = 0;
-    HashMap *hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                                   free, free, HASH_MAP_INIT_SIZE);
 
     size_t orig_size = hashmap->size;
@@ -253,7 +253,7 @@ static void test_grow(void)
 static void test_shrink(void)
 {
     unsigned int i = 0;
-    HashMap *hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                                   free, free, HASH_MAP_INIT_SIZE);
 
     size_t orig_size = hashmap->size;
@@ -311,7 +311,7 @@ static void test_shrink(void)
 
 static void test_no_shrink_below_init_size(void)
 {
-    HashMap *hashmap = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *hashmap = HashMapNew(StringHash_untyped, StringEqual_untyped,
                                   free, free, HASH_MAP_INIT_SIZE);
 
     assert_int_equal(hashmap->size, HASH_MAP_INIT_SIZE);
@@ -367,7 +367,7 @@ static void test_clear(void)
 
 static void test_clear_hashmap(void)
 {
-    HashMap *map = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *map = HashMapNew(StringHash_untyped, StringEqual_untyped,
                               free, free, HASH_MAP_INIT_SIZE);
 
     assert_false(HashMapInsert(map, xstrdup("one"), xstrdup("first")));
@@ -499,7 +499,7 @@ static void test_hashmap_new_destroy(void)
 
 static void test_hashmap_degenerate_hash_fn(void)
 {
-    HashMap *hashmap = HashMapNew(ConstHash, StringSafeEqual_untyped, free, free, HASH_MAP_INIT_SIZE);
+    HashMap *hashmap = HashMapNew(ConstHash, StringEqual_untyped, free, free, HASH_MAP_INIT_SIZE);
 
     for (int i = 0; i < 100; i++)
     {
@@ -528,7 +528,7 @@ typedef struct
  * any references in the new value are not invalid. */
 static void test_array_map_key_referenced_in_value(void)
 {
-    ArrayMap *m = ArrayMapNew(StringSafeEqual_untyped, free, free);
+    ArrayMap *m = ArrayMapNew(StringEqual_untyped, free, free);
 
     char      *key1 = xstrdup("blah");
     TestValue *val1 = xmalloc(sizeof(*val1));
@@ -574,7 +574,7 @@ static void test_array_map_key_referenced_in_value(void)
 /* Same purpose as the above test. */
 static void test_hash_map_key_referenced_in_value(void)
 {
-    HashMap *m = HashMapNew(StringHash_untyped, StringSafeEqual_untyped,
+    HashMap *m = HashMapNew(StringHash_untyped, StringEqual_untyped,
                             free, free, HASH_MAP_INIT_SIZE);
     char      *key1 = xstrdup("blah");
     TestValue *val1 = xmalloc(sizeof(*val1));

--- a/tests/unit/string_lib_test.c
+++ b/tests/unit/string_lib_test.c
@@ -542,19 +542,19 @@ static void test_safe_compare(void)
 
 static void test_safe_equal(void)
 {
-    assert_true(StringSafeEqual(NULL, NULL));
-    assert_true(StringSafeEqual("a", "a"));
-    assert_true(StringSafeEqual("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"));
-    assert_true(StringSafeEqual("0123456789", "0123456789"));
-    assert_true(StringSafeEqual("CamelCase", "CamelCase"));
-    assert_true(StringSafeEqual("(){}[]<>", "(){}[]<>"));
-    assert_true(StringSafeEqual("+-*/%%^", "+-*/%%^"));
+    assert_true(StringEqual(NULL, NULL));
+    assert_true(StringEqual("a", "a"));
+    assert_true(StringEqual("abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"));
+    assert_true(StringEqual("0123456789", "0123456789"));
+    assert_true(StringEqual("CamelCase", "CamelCase"));
+    assert_true(StringEqual("(){}[]<>", "(){}[]<>"));
+    assert_true(StringEqual("+-*/%%^", "+-*/%%^"));
 
-    assert_false(StringSafeEqual("", NULL));
-    assert_false(StringSafeEqual(NULL, ""));
-    assert_false(StringSafeEqual("a", "b"));
-    assert_false(StringSafeEqual("a", "A"));
-    assert_false(StringSafeEqual("abc def", "abc deF"));
+    assert_false(StringEqual("", NULL));
+    assert_false(StringEqual(NULL, ""));
+    assert_false(StringEqual("a", "b"));
+    assert_false(StringEqual("a", "A"));
+    assert_false(StringEqual("abc def", "abc deF"));
 }
 
 static void test_safe_compare_ignore_case(void)
@@ -590,31 +590,31 @@ static void test_safe_compare_ignore_case(void)
 
 static void test_safe_equal_ignore_case(void)
 {
-    assert_true(StringSafeEqual_IgnoreCase(NULL, NULL));
-    assert_true(StringSafeEqual_IgnoreCase("a", "a"));
-    assert_true(StringSafeEqual_IgnoreCase("a", "A"));
-    assert_true(StringSafeEqual_IgnoreCase(hi_alphabet, lo_alphabet));
-    assert_true(StringSafeEqual_IgnoreCase("0123456789", "0123456789"));
-    assert_true(StringSafeEqual_IgnoreCase("CamelCase", "camelcase"));
-    assert_true(StringSafeEqual_IgnoreCase("(){}[]<>", "(){}[]<>"));
-    assert_true(StringSafeEqual_IgnoreCase("+-*/%%^", "+-*/%%^"));
-    assert_true(StringSafeEqual_IgnoreCase("abc def", "abc deF"));
+    assert_true(StringEqual_IgnoreCase(NULL, NULL));
+    assert_true(StringEqual_IgnoreCase("a", "a"));
+    assert_true(StringEqual_IgnoreCase("a", "A"));
+    assert_true(StringEqual_IgnoreCase(hi_alphabet, lo_alphabet));
+    assert_true(StringEqual_IgnoreCase("0123456789", "0123456789"));
+    assert_true(StringEqual_IgnoreCase("CamelCase", "camelcase"));
+    assert_true(StringEqual_IgnoreCase("(){}[]<>", "(){}[]<>"));
+    assert_true(StringEqual_IgnoreCase("+-*/%%^", "+-*/%%^"));
+    assert_true(StringEqual_IgnoreCase("abc def", "abc deF"));
 
-    assert_false(StringSafeEqual_IgnoreCase("", NULL));
-    assert_false(StringSafeEqual_IgnoreCase(NULL, ""));
-    assert_false(StringSafeEqual_IgnoreCase("a", "b"));
+    assert_false(StringEqual_IgnoreCase("", NULL));
+    assert_false(StringEqual_IgnoreCase(NULL, ""));
+    assert_false(StringEqual_IgnoreCase("a", "b"));
 }
 
 static void test_safe_equal_n(void)
 {
-    assert_true(StringSafeEqualN("abcd", "abcX", 3));
-    assert_true(StringSafeEqualN_IgnoreCase("abcd", "ABCX", 3));
+    assert_true(StringEqualN("abcd", "abcX", 3));
+    assert_true(StringEqualN_IgnoreCase("abcd", "ABCX", 3));
 
-    assert_false(StringSafeEqualN("abcd", "abXX", 3));
-    assert_false(StringSafeEqualN_IgnoreCase("abcd", "ABXX", 3));
+    assert_false(StringEqualN("abcd", "abXX", 3));
+    assert_false(StringEqualN_IgnoreCase("abcd", "ABXX", 3));
 
-    assert_true(StringSafeEqualN("123abc", "123abc", 1000));
-    assert_true(StringSafeEqualN_IgnoreCase("123abc", "123ABC", 1000));
+    assert_true(StringEqualN("123abc", "123abc", 1000));
+    assert_true(StringEqualN_IgnoreCase("123abc", "123ABC", 1000));
 }
 
 static void test_match(void)


### PR DESCRIPTION
This has annoyed me for quite some time.
There are many reasons to do this:

* It's shorter, faster to type and read and causes less line-splitting
* Safe should be default anyway, unsafe functions should be marked as such
* Easier to remember (Is it StringSafeEqual or SafeStringEqual?)