### PR TITLE
Cleaned up IP address comparison functions

### DIFF
--- a/libutils/ip_address.h
+++ b/libutils/ip_address.h
@@ -89,8 +89,8 @@ bool IPAddressIsIPAddress(Buffer *source, IPAddress **address);
   @brief Compares two IP addresses for sorting.
   @param a IP address of the first object.
   @param b IP address of the second object.
-  @return 1 if a < b, and 0 otherwise.
+  @return true if a < b, false otherwise.
   */
-int IPAddressCompareLess(IPAddress *a, IPAddress *b);
+bool IPAddressCompareLess(IPAddress *a, IPAddress *b);
 
 #endif // CFENGINE_IP_ADDRESS_H


### PR DESCRIPTION
More cases of functions and variables which should be bool.
AFAICT the -1 return value was unreachable anyway. (And it was
treated as bool in the calling location).

Also refactored IPAddressCompareLess() to follow code style,
fixed indentation, added assertions and comments to make it
easier to understand.

Reported by LGTM:
https://lgtm.com/rules/1508604166004/