### PR TITLE
Functions for handling 64-bit numbers from JSON files

### DIFF
--- a/libutils/json.c
+++ b/libutils/json.c
@@ -754,6 +754,34 @@ long JsonPrimitiveGetAsInteger(const JsonElement *const primitive)
     return StringToLongExitOnError(primitive->primitive.value);
 }
 
+
+int JsonPrimitiveGetAsInt64(const JsonElement *primitive, int64_t *value_out)
+{
+    assert(primitive != NULL);
+    assert(primitive->type == JSON_ELEMENT_TYPE_PRIMITIVE);
+    assert(primitive->primitive.type == JSON_PRIMITIVE_TYPE_INTEGER);
+
+    return StringToInt64(primitive->primitive.value, value_out);
+}
+
+int64_t JsonPrimitiveGetAsInt64DefaultOnError(const JsonElement *primitive, int64_t default_return)
+{
+    assert(primitive != NULL);
+    assert(primitive->type == JSON_ELEMENT_TYPE_PRIMITIVE);
+    assert(primitive->primitive.type == JSON_PRIMITIVE_TYPE_INTEGER);
+
+    return StringToInt64DefaultOnError(primitive->primitive.value, default_return);
+}
+
+int64_t JsonPrimitiveGetAsInt64ExitOnError(const JsonElement *primitive)
+{
+    assert(primitive != NULL);
+    assert(primitive->type == JSON_ELEMENT_TYPE_PRIMITIVE);
+    assert(primitive->primitive.type == JSON_PRIMITIVE_TYPE_INTEGER);
+
+    return StringToInt64ExitOnError(primitive->primitive.value);
+}
+
 double JsonPrimitiveGetAsReal(const JsonElement *const primitive)
 {
     assert(primitive != NULL);

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -27,6 +27,7 @@
 
 #include <regex.h>
 #include <writer.h>
+#include <inttypes.h> // int64_t
 
 /**
   @brief JSON data-structure.
@@ -199,6 +200,9 @@ const char *JsonPrimitiveGetAsString(const JsonElement *primitive);
 char *JsonPrimitiveToString(const JsonElement *primitive);
 bool JsonPrimitiveGetAsBool(const JsonElement *primitive);
 long JsonPrimitiveGetAsInteger(const JsonElement *primitive);
+int JsonPrimitiveGetAsInt64(const JsonElement *primitive, int64_t *value_out);
+int64_t JsonPrimitiveGetAsInt64DefaultOnError(const JsonElement *primitive, int64_t default_return);
+int64_t JsonPrimitiveGetAsInt64ExitOnError(const JsonElement *primitive);
 double JsonPrimitiveGetAsReal(const JsonElement *primitive);
 
 JsonElement *JsonStringCreate(const char *value);

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -26,6 +26,7 @@
 #define CFENGINE_STRING_LIB_H
 
 #include <stdbool.h> // bool
+#include <stdint.h>  // int64_t
 #include <string.h>  // strstr()
 #include <stdarg.h> // va_list
 #include <compiler.h>
@@ -72,6 +73,9 @@ void LogStringToLongError(const char *str_attempted, const char *id, int error_c
 long StringToLongDefaultOnError(const char *str, long default_return);
 long StringToLongExitOnError(const char *str);
 long StringToLongUnsafe(const char *str); // Deprecated, do not use
+int StringToInt64(const char *str, int64_t *value_out);
+int64_t StringToInt64DefaultOnError(const char *str, int64_t default_return);
+int64_t StringToInt64ExitOnError(const char *str);
 
 char *StringFromLong(long number);
 double StringToDouble(const char *str);

--- a/tests/unit/json_test.c
+++ b/tests/unit/json_test.c
@@ -4,6 +4,7 @@
 #include <string_lib.h>
 #include <file_lib.h>
 #include <misc_lib.h> /* xsnprintf */
+#include <alloc.h>    // xasprintf()
 
 #include <float.h>
 
@@ -918,6 +919,103 @@ static void test_parse_escaped_string(void)
     }
 }
 
+static void test_parse_big_numbers(void)
+{
+#define JSON_TEST_BIG_NUMBER "9999999999"
+    // JsonPrimitiveGetAsInt64():
+    {
+        const char *data = "[" JSON_TEST_BIG_NUMBER "]";
+        JsonElement *json = NULL;
+        assert_int_equal(JSON_PARSE_OK, JsonParse(&data, &json));
+        assert_true(json != NULL);
+
+        const JsonElement *const primitive = JsonArrayGet(json, 0);
+        int64_t number;
+        const int error_code = JsonPrimitiveGetAsInt64(primitive, &number);
+        assert_int_equal(error_code, 0);
+        char *result;
+        xasprintf(&result, "%jd", (intmax_t) number);
+        assert_string_equal(result, JSON_TEST_BIG_NUMBER);
+        free(result);
+        JsonDestroy(json);
+    }
+    {
+        const char *data = "[-" JSON_TEST_BIG_NUMBER "]";
+        JsonElement *json = NULL;
+        assert_int_equal(JSON_PARSE_OK, JsonParse(&data, &json));
+        assert_true(json != NULL);
+
+        const JsonElement *const primitive = JsonArrayGet(json, 0);
+        int64_t number;
+        const int error_code = JsonPrimitiveGetAsInt64(primitive, &number);
+        assert_int_equal(error_code, 0);
+        char *result;
+        xasprintf(&result, "%jd", (intmax_t) number);
+        assert_string_equal(result, "-" JSON_TEST_BIG_NUMBER);
+        free(result);
+        JsonDestroy(json);
+    }
+    // JsonPrimitiveGetAsInt64DefaultOnError():
+    {
+        const char *data = "[" JSON_TEST_BIG_NUMBER "]";
+        JsonElement *json = NULL;
+        assert_int_equal(JSON_PARSE_OK, JsonParse(&data, &json));
+        assert_true(json != NULL);
+
+        const JsonElement *const primitive = JsonArrayGet(json, 0);
+        const int64_t number = JsonPrimitiveGetAsInt64DefaultOnError(primitive, -1);
+        char *result;
+        xasprintf(&result, "%jd", (intmax_t) number);
+        assert_string_equal(result, JSON_TEST_BIG_NUMBER);
+        free(result);
+        JsonDestroy(json);
+    }
+    {
+        const char *data = "[-" JSON_TEST_BIG_NUMBER "]";
+        JsonElement *json = NULL;
+        assert_int_equal(JSON_PARSE_OK, JsonParse(&data, &json));
+        assert_true(json != NULL);
+
+        const JsonElement *const primitive = JsonArrayGet(json, 0);
+        const int64_t number = JsonPrimitiveGetAsInt64DefaultOnError(primitive, -1);
+        char *result;
+        xasprintf(&result, "%jd", (intmax_t) number);
+        assert_string_equal(result, "-" JSON_TEST_BIG_NUMBER);
+        free(result);
+        JsonDestroy(json);
+    }
+    // JsonPrimitiveGetAsInt64ExitOnError():
+    {
+        const char *data = "[" JSON_TEST_BIG_NUMBER "]";
+        JsonElement *json = NULL;
+        assert_int_equal(JSON_PARSE_OK, JsonParse(&data, &json));
+        assert_true(json != NULL);
+
+        const JsonElement *const primitive = JsonArrayGet(json, 0);
+        const int64_t number = JsonPrimitiveGetAsInt64ExitOnError(primitive);
+        char *result;
+        xasprintf(&result, "%jd", (intmax_t) number);
+        assert_string_equal(result, JSON_TEST_BIG_NUMBER);
+        free(result);
+        JsonDestroy(json);
+    }
+    {
+        const char *data = "[-" JSON_TEST_BIG_NUMBER "]";
+        JsonElement *json = NULL;
+        assert_int_equal(JSON_PARSE_OK, JsonParse(&data, &json));
+        assert_true(json != NULL);
+
+        const JsonElement *const primitive = JsonArrayGet(json, 0);
+        const int64_t number = JsonPrimitiveGetAsInt64ExitOnError(primitive);
+        char *result;
+        xasprintf(&result, "%jd", (intmax_t) number);
+        assert_string_equal(result, "-" JSON_TEST_BIG_NUMBER);
+        free(result);
+        JsonDestroy(json);
+    }
+#undef JSON_TEST_BIG_NUMBER
+}
+
 static void test_parse_good_numbers(void)
 {
     {
@@ -1557,6 +1655,7 @@ int main()
         unit_test(test_parse_empty_containers),
         unit_test(test_parse_empty_string),
         unit_test(test_parse_escaped_string),
+        unit_test(test_parse_big_numbers),
         unit_test(test_parse_good_numbers),
         unit_test(test_parse_object_compound),
         unit_test(test_parse_object_diverse),

--- a/tests/unit/sequence_test.c
+++ b/tests/unit/sequence_test.c
@@ -524,6 +524,7 @@ static void test_get_data(void)
     for (size_t i = 4; i < 16; i++)
     {
         void *item = data[i];
+        UNUSED(item);
     }
 
     /* no leak here, 'data' is not a copy */


### PR DESCRIPTION
Generally in the CFEngine codebase we use `long`, but on some platforms, `long` is 32-bit. When you need to handle bigger numbers, using `int64_t` is better.