### PR TITLE
CFE-3489: Mustache: Added warning when trying to use {{.}} to expand containers

### DIFF
--- a/libutils/mustache.c
+++ b/libutils/mustache.c
@@ -490,6 +490,18 @@ static bool RenderVariable(Buffer *out,
             // because we return false earlier otherwise
             return RenderVariablePrimitive(out, var, escape, json_key);
         }
+        else if (item_mode)
+        {
+            // This can happen in 2 cases:
+            // if you try to use {{.}} on the top element (without iterating)
+            // if you try to use {{.}} while iterating and the current element is a container
+            // In both cases we want to give an error(warning) since this is not clear in the
+            // mustache spec
+            Log(LOG_LEVEL_WARNING,
+                "{{.}} mustache tag cannot expand a container without specifying conversion"
+                " - consider {{$.}} or {{%%.}}");
+            return false;
+        }
     }
 
     assert(false);


### PR DESCRIPTION
Example:

```
root@OH-WIN:/northern.tech/cfengine/core# cat test.cf
bundle agent firewall
{
  vars:
      "_defaults" data => '{ "source": "0.0.0.0/0", "protocol": "tcp" }';
      "cfengine" data => mergedata( @(_defaults), '{"name": "cfengine" "destination-port": "5308" }' );
      "RULES" data => mergedata( '{ "ACCEPT": [ cfengine ]}' );
    reports:
      "$(with)" with => string_mustache( "{{#ACCEPT}}{{.}}{{/ACCEPT}}", RULES );
}
bundle agent __main__
{
    methods:
      "firewall";
    reports:
      "CFEngine $(sys.cf_version)";
}
root@OH-WIN:/northern.tech/cfengine/core# /var/cfengine/bin/cf-agent -KI test.cf
 warning: {{.}} mustache tag cannot expand a container without specifying conversion - consider {{$.}} or {{%.}}
 warning: {{.}} mustache tag cannot expand a container without specifying conversion - consider {{$.}} or {{%.}}
 warning: {{.}} mustache tag cannot expand a container without specifying conversion - consider {{$.}} or {{%.}}
 warning: {{.}} mustache tag cannot expand a container without specifying conversion - consider {{$.}} or {{%.}}
R: $(with)
 warning: {{.}} mustache tag cannot expand a container without specifying conversion - consider {{$.}} or {{%.}}
 warning: {{.}} mustache tag cannot expand a container without specifying conversion - consider {{$.}} or {{%.}}
 warning: {{.}} mustache tag cannot expand a container without specifying conversion - consider {{$.}} or {{%.}}
 warning: {{.}} mustache tag cannot expand a container without specifying conversion - consider {{$.}} or {{%.}}
R: CFEngine 3.17.0a.782c013a0
root@OH-WIN:/northern.tech/cfengine/core# sed "s/{{.}}/{{$.}}/g" -i test.cf
root@OH-WIN:/northern.tech/cfengine/core# cat test.cf
bundle agent firewall
{
  vars:
      "_defaults" data => '{ "source": "0.0.0.0/0", "protocol": "tcp" }';
      "cfengine" data => mergedata( @(_defaults), '{"name": "cfengine" "destination-port": "5308" }' );
      "RULES" data => mergedata( '{ "ACCEPT": [ cfengine ]}' );
    reports:
      "$(with)" with => string_mustache( "{{#ACCEPT}}{{$.}}{{/ACCEPT}}", RULES );
}
bundle agent __main__
{
    methods:
      "firewall";
    reports:
      "CFEngine $(sys.cf_version)";
}
root@OH-WIN:/northern.tech/cfengine/core# /var/cfengine/bin/cf-agent -KI test.cf
R: {"destination-port":"5308","name":"cfengine","protocol":"tcp","source":"0.0.0.0/0"}
R: CFEngine 3.17.0a.782c013a0
root@OH-WIN:/northern.tech/cfengine/core#
```

The mustache manual doesn't mention `{{.}}` at all:

http://mustache.github.io/mustache.5.html

Mustache.js documentation does mention it:

https://github.com/janl/mustache.js/#non-empty-lists

But only what it should do when iterating over a list of strings.

Some references in the "spec":

https://github.com/mustache/mustache/issues/129
https://github.com/mustache/spec/blob/master/specs/sections.yml#L141-L169

But no mention of what should happen in these edge cases / wrong usage.

So, I don't think we should copy the behavior of the mustache demo in this case, because

1. It's not described anywhere in the spec
2. It seems accidental:

Mustache template
```
{{.}}
```

Data:
```
[1,"a",{},[1,2]]
```

Output:
```
1,a,[object Object],1,2
```

JavaScript:

```
$ node
Welcome to Node.js v14.15.0.
Type ".help" for more information.
> String([1,2,3])
'1,2,3'
> String({})
'[object Object]'
> String(["a","b","c"])
'a,b,c'
> String([1,"a",{},[1,2]])
'1,a,[object Object],1,2'
```

See JIRA tickets for further explanation:
https://tracker.mender.io/browse/CFE-3457
https://tracker.mender.io/browse/CFE-3489