### PR TITLE
Add ARM64 job in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: xenial
+dist: bionic
 
 addons:
   artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,21 @@ matrix:
     - os: osx
       env: JOB_TYPE=compile_and_unit_test COVERAGE=no
       sudo: false
+    - arch: arm64
+      os: linux
+      env: JOB_TYPE=compile_and_unit_test_asan
+    - arch: arm64
+      os: linux
+      env: JOB_TYPE=compile_and_unit_test_no_deps COVERAGE=no
+    - arch: arm64
+      os: linux
+      env: JOB_TYPE=compile_and_unit_test COVERAGE=no
+      compiler: clang
 
 before_install:
+  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
+        sudo apt-get install -y libpcre3 libpcre3-dev;
+    fi
   - chmod ug+x ./travis-scripts/*
   - ./travis-scripts/before_install.sh
 

--- a/libutils/buffer.c
+++ b/libutils/buffer.c
@@ -111,7 +111,14 @@ int BufferCompare(const Buffer *buffer1, const Buffer *buffer2)
             /*
              * C String comparison
              */
-            return strcmp(buffer1->buffer, buffer2->buffer);
+            // Adding this as strcmp gives difference of the buffer values in aarch64
+            // Whereas it gives 1, 0 or -1 in other platforms accordingly.
+            int compare_result = strcmp(buffer1->buffer, buffer2->buffer);
+            if (compare_result != 0)
+            {
+                  compare_result = compare_result / abs(compare_result);
+            }
+            return compare_result;
         }
         else
         {

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -231,7 +231,14 @@ int StringSafeCompare(const char *const a, const char *const b)
     }
     if (a != NULL && b != NULL)
     {
-        return strcmp(a, b);
+        // Adding this as strcmp gives difference of the buffer values in aarch64
+        // Whereas it gives 1, 0 or -1 in other platforms accordingly.
+        int compare_result = strcmp(a, b);
+        if (compare_result != 0)
+        {
+            compare_result = compare_result / abs(compare_result);
+        }
+        return compare_result;
     }
 
     // Weird edge cases where one is NULL:


### PR DESCRIPTION
 - .travis.yml : Added Arm64 jobs along with the installation of package require for arm64
 - libutils/[buffer.c, string_lib.c]: Fixed strcmp() issue for arm64
   - strcmp() has different behavior in arm64 and amd64. At ARM64, strcmp(char* a, char* b) returns the value other than 1 or -1, as per given char buffer inputs.
   - While asserting buf_size in libutils/string_lib.c in line 65, added typecasting as in ARM64 'char' is considered as 'unsigned char' whereas AMD64 treats 'char' as 'signed char'

Signed-off-by: odidev <odidev@puresoftware.com>