### PR TITLE
Removed line split to ease debugging

### DIFF
--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -561,11 +561,10 @@ setnetgrent(const char *netgroup);
 
 #if !HAVE_DECL_ENDNETGRENT
 #if ENDNETGRENT_RETURNS_INT
-int
+int endnetgrent(void);
 #else
-void
+void endnetgrent(void);
 #endif
-endnetgrent(void);
 #endif
 
 #if !HAVE_DECL_STRSTR


### PR DESCRIPTION
This made it more annoying to debug for me, since
the compiler would point me to the last (shared) line,
which doesn't have the relevant information (the return type).