### PR TITLE
Removed line split to maintain consistancy

### DIFF
--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -560,11 +560,10 @@ int getnetgrent(char **host, char **user, char **domain);
 
 #if !HAVE_DECL_SETNETGRENT
 #if SETNETGRENT_RETURNS_INT
-int
+int setnetgrent(const char *netgroup);
 #else
-void
+void setnetgrent(const char *netgroup);
 #endif
-setnetgrent(const char *netgroup);
 #endif
 
 #if !HAVE_DECL_ENDNETGRENT


### PR DESCRIPTION
Line split was removed for `endnetgrent` below in commit c77a9a4 due to
annoyance while debugging. I'll do the same with `setnetgrent` for the
sake of consistancy.

Changelog: None
Ticket: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>