### PR TITLE
CFE-3540: GitHub Actions: Added MacOS Unit Tests

### DIFF
--- a/.github/workflows/asan_unit_tests.yml
+++ b/.github/workflows/asan_unit_tests.yml
@@ -1,4 +1,4 @@
-name: Build and unit test
+name: ASAN Unit Tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  unit_tests:
+  asan_unit_tests:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -1,0 +1,23 @@
+name: MacOS Unit Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  macos_unit_tests:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: brew install lmdb automake
+    - name: Run autotools / configure
+      run: ./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl)"
+    - name: Compile and link
+      run: make -j8 CFLAGS="-Werror -Wall"
+    - name: Run unit tests
+      run: make -C tests/unit check


### PR DESCRIPTION
At first I was adding it to the same workflow as Ubuntu, but
this became ugly, since there are many differences. A separate
workflow (yml) makes it much cleaner.

Running with ASAN on MacOS requires some more work, but this gets us halfway there.