### PR TITLE
Make JsonEncodeStringWriter() a public function in libutils

### DIFF
--- a/libutils/json.c
+++ b/libutils/json.c
@@ -883,7 +883,7 @@ JsonElement *JsonObjectCreate(const size_t initialCapacity)
         JSON_CONTAINER_TYPE_OBJECT, NULL, initialCapacity);
 }
 
-static void JsonEncodeStringWriter(
+void JsonEncodeStringWriter(
     const char *const unescaped_string, Writer *const writer)
 {
     assert(unescaped_string != NULL);

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -537,4 +537,6 @@ void JsonWrite(
 
 void JsonWriteCompact(Writer *w, const JsonElement *element);
 
+void JsonEncodeStringWriter(const char *const unescaped_string, Writer *const writer);
+
 #endif


### PR DESCRIPTION
It is useful in code writing out JSON without actually creating
then JSON structures in memory (to avoid data duplication, etc.).

Ticket: ENT-6182
Changelog: None