### PR TITLE
Removed unnecessary assert comparison

### DIFF
--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -1407,7 +1407,7 @@ size_t TrimCSVLineCRLFStrict(char *const data)
 void StringCloseHole(char *s, const size_t start, const size_t end)
 {
     assert(s != NULL);
-    assert(0 <= start && start <= end && end <= strlen(s));
+    assert(start <= end && end <= strlen(s));
     assert((end - start) <= strlen(s));
 
     if (end > start)


### PR DESCRIPTION
Variable of unsigned type was checked to be greater that zero.

Changelog: None
Ticket: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>