### PR TITLE
Add a new NDEBUG_UNUSED macro for variables only used in debug builds

### DIFF
--- a/libutils/compiler.h
+++ b/libutils/compiler.h
@@ -70,6 +70,16 @@
 
 
 /**
+ * For variables only used in debug builds, in particular only in assert()
+ * calls, use NDEBUG_UNUSED.
+ */
+#ifdef NDEBUG
+#define NDEBUG_UNUSED __attribute__((unused))
+#else
+#define NDEBUG_UNUSED
+#endif
+
+/**
  * If you want a string literal version of a macro, useful in scanf formats:
  *
  * #define BUFSIZE 1024


### PR DESCRIPTION
Sometimes a variables is only used in an assertion like
'assert(ret > 0)` which results in a compilation warning/error
when compiling without '--enable-debug' because in such cases
all 'assert()' are removed.