### PR TITLE
Return NULL from FileWriter() and CsvWriterOpen() if they get NULL

### DIFF
--- a/libutils/csv_writer.c
+++ b/libutils/csv_writer.c
@@ -52,6 +52,10 @@ CsvWriter *CsvWriterOpenSpecifyTerminate(Writer *w, bool terminate_last_line)
 
 CsvWriter *CsvWriterOpen(Writer *w)
 {
+    if (w == NULL)
+    {
+        return NULL;
+    }
     return CsvWriterOpenSpecifyTerminate(w, true);
 }
 

--- a/libutils/writer.c
+++ b/libutils/writer.c
@@ -55,6 +55,10 @@ struct Writer_
 
 Writer *FileWriter(FILE *file)
 {
+    if (file == NULL)
+    {
+        return NULL;
+    }
     Writer *writer = xcalloc(1, sizeof(Writer));
 
     writer->type = WT_FILE;


### PR DESCRIPTION
This makes use of the two "constructors" easier because the code
can simply look like this:

  FILE *file = fopen(...);
  Writer *writer = FileWriter(file);
  CsvWriter *csv_writer = CsvWriterOpen(writer);

  if (csv_writer == NULL)
  {
      /* handle error */
  }

instead of checking each return value for != NULL. It usually
doesn't matter much which phase exactly failed.

Ticket: CFE-3554
Changelog: None