### PR TITLE
CFE-3416: Fixed implicit-fallthrough compiler warnings on multiple files

### DIFF
--- a/libutils/json.c
+++ b/libutils/json.c
@@ -2019,7 +2019,9 @@ static JsonParseError JsonParseAsString(
             switch (**data)
             {
             case '\\':
+                break;
             case '"':
+                break;
             case '/':
                 break;
 
@@ -2052,7 +2054,7 @@ static JsonParseError JsonParseAsString(
                 WriterWriteChar(writer, '\\');
                 break;
             }
-            /* Deliberate fall-through */
+            /* fall through */
         default:
             WriterWriteChar(writer, **data);
             break;

--- a/libutils/mustache.c
+++ b/libutils/mustache.c
@@ -252,6 +252,7 @@ static Mustache NextTag(const char *input,
         break;
     case '{':
         extra_end = "}";
+        // fall through
     case '&':
         ret.type = TAG_TYPE_VAR_UNESCAPED;
         ret.content++;
@@ -810,10 +811,10 @@ static bool Render(Buffer *out, const char *start, const char *input, Seq *hash_
                                 free(cur_section);
                                 break;
                             }
-                            /* else fall through to the case below because
-                             * iterated objects and arrays are processed in the
-                             * same way */
                         }
+                        /* fall through */
+                        /* Because iterated objects and arrays are processed in the
+                         * same way */
                     case JSON_CONTAINER_TYPE_ARRAY:
                         if (JsonLength(var) > 0)
                         {


### PR DESCRIPTION
In an attempt to silence deliberate fall throughs
while being portable, an one line comment `/* fall through */`
was inserted at the end of the fall through-ing case.