### PR TITLE
Added autoconf message for whether debug option is present

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -231,10 +231,13 @@ dnl as last, some macro seem to messes the order up and insert
 dnl its own optimisation flags as well. So we append ENV_CFLAGS
 dnl at the end manually, causing a bit of flag duplication.
 
+AC_MSG_CHECKING([for debug option])
 if test x"$debug" = x"yes"
 then
+    AC_MSG_RESULT(yes)
     CFLAGS="$CFLAGS -g3 -O0 $ENV_CFLAGS"
 else
+    AC_MSG_RESULT(no)
     CFLAGS="$CFLAGS -O2 -DNDEBUG $ENV_CFLAGS"
 fi
 


### PR DESCRIPTION
This option was useful to confirm that libntech is built
with debug options. I though I might leave it in.