### PR TITLE
Remove an always-true assert from StringCopy()

### DIFF
--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -62,7 +62,6 @@ size_t StringCopy(const char *const from, char *const to, const size_t buf_size)
     assert(from != NULL);
     assert(to != NULL);
     assert(from != to);
-    assert(buf_size >= 0UL);
 
     memset(to, 0, buf_size);
     strncpy(to, from, buf_size);


### PR DESCRIPTION
No point in asserting that an unsigned value is >= 0.