### PR TITLE
CFE-3648: Added function JsonArrayExtend to libntech

### DIFF
--- a/libutils/json.c
+++ b/libutils/json.c
@@ -1353,6 +1353,30 @@ void JsonArrayAppendElement(
     SeqAppend(array->container.children, element);
 }
 
+void JsonArrayExtend(JsonElement *array1, JsonElement *array2)
+{
+    assert(array1 != NULL);
+    assert(array1->type == JSON_ELEMENT_TYPE_CONTAINER);
+    assert(array1->container.type == JSON_CONTAINER_TYPE_ARRAY);
+    assert(array2 != NULL);
+    assert(array2->type == JSON_ELEMENT_TYPE_CONTAINER);
+    assert(array2->container.type == JSON_CONTAINER_TYPE_ARRAY);
+
+    JsonIterator iter = JsonIteratorInit(array2);
+    JsonElement *element = JsonIteratorNextValue(&iter);
+    while (element != NULL)
+    {
+        JsonArrayAppendElement(array1, element);
+        element = JsonIteratorNextValue(&iter);
+    }
+
+    if (array2->propertyName != NULL)
+    {
+        free(array2->propertyName);
+    }
+    free(array2);
+}
+
 void JsonArrayRemoveRange(
     JsonElement *const array, const size_t start, const size_t end)
 {

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -417,6 +417,14 @@ void JsonArrayAppendObject(JsonElement *array, JsonElement *object);
 void JsonArrayAppendElement(JsonElement *array, JsonElement *element);
 
 /**
+  * @brief Add elements from `array2` to `array1`.
+  * @param array1 [in/out] The JSON array to add elements to.
+  * @param array2 [in] The JSON array to add elements from.
+  * @note `array1` takes ownership of elements in `array2`. `array2` is freed.
+  */
+void JsonArrayExtend(JsonElement *array1, JsonElement *array2);
+
+/**
   @brief Remove an inclusive range from a JSON array.
   @see SequenceRemoveRange
   @param array [in] The JSON array parent.

--- a/tests/unit/json_test.c
+++ b/tests/unit/json_test.c
@@ -1405,6 +1405,67 @@ static void test_parse_array_nested_garbage(void)
     }
 }
 
+static void test_array_extend(void)
+{
+    {
+        JsonElement *arr1 = JsonArrayCreate(6);
+        JsonArrayAppendString(arr1, "one");
+        JsonArrayAppendString(arr1, "two");
+        JsonArrayAppendString(arr1, "three");
+
+        JsonElement *arr2 = JsonArrayCreate(3);
+        JsonArrayAppendString(arr2, "four");
+        JsonArrayAppendString(arr2, "five");
+        JsonArrayAppendString(arr2, "six");
+
+        JsonArrayExtend(arr1, arr2);
+
+        assert_int_equal(JsonLength(arr1), 6);
+        assert_string_equal(JsonArrayGetAsString(arr1, 0), "one");
+        assert_string_equal(JsonArrayGetAsString(arr1, 1), "two");
+        assert_string_equal(JsonArrayGetAsString(arr1, 2), "three");
+        assert_string_equal(JsonArrayGetAsString(arr1, 3), "four");
+        assert_string_equal(JsonArrayGetAsString(arr1, 4), "five");
+        assert_string_equal(JsonArrayGetAsString(arr1, 5), "six");
+
+        JsonDestroy(arr1);
+    }
+    {
+        JsonElement *arr1 = JsonArrayCreate(3);
+        JsonArrayAppendString(arr1, "one");
+        JsonArrayAppendString(arr1, "two");
+        JsonArrayAppendString(arr1, "three");
+
+        JsonElement *arr2 = JsonArrayCreate(0);
+
+        JsonArrayExtend(arr1, arr2);
+
+        assert_int_equal(JsonLength(arr1), 3);
+        assert_string_equal(JsonArrayGetAsString(arr1, 0), "one");
+        assert_string_equal(JsonArrayGetAsString(arr1, 1), "two");
+        assert_string_equal(JsonArrayGetAsString(arr1, 2), "three");
+
+        JsonDestroy(arr1);
+    }
+    {
+        JsonElement *arr1 = JsonArrayCreate(3);
+
+        JsonElement *arr2 = JsonArrayCreate(3);
+        JsonArrayAppendString(arr2, "four");
+        JsonArrayAppendString(arr2, "five");
+        JsonArrayAppendString(arr2, "six");
+
+        JsonArrayExtend(arr1, arr2);
+
+        assert_int_equal(JsonLength(arr1), 3);
+        assert_string_equal(JsonArrayGetAsString(arr1, 0), "four");
+        assert_string_equal(JsonArrayGetAsString(arr1, 1), "five");
+        assert_string_equal(JsonArrayGetAsString(arr1, 2), "six");
+
+        JsonDestroy(arr1);
+    }
+}
+
 static void test_array_remove_range(void)
 {
     {
@@ -1732,6 +1793,7 @@ int main()
         unit_test(test_array_get_string),
         unit_test(test_array_iterator),
         unit_test(test_array_remove_range),
+        unit_test(test_array_extend),
         unit_test(test_copy_compare),
         unit_test(test_detach_key_from_object),
         unit_test(test_iterator_current),


### PR DESCRIPTION
Function JsonArrayExtend inserts elements from one JSON array to the end
of another JSON array.

Ticket: CFE-3648
Changelog: None
Signed-off-by: larsewi <lars.erik.wik@northern.tech>

merge together: [cfengine/core#4602](https://github.com/cfengine/core/pull/4602)