### PR TITLE
Added StringDecimalToLong utility function

### DIFF
--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -67,6 +67,8 @@ char ToUpper(char ch);
 void ToUpperStrInplace(char *str);
 void ToLowerStrInplace(char *str);
 
+int StringDecimalToLong(const char *str, long *value_out) FUNC_WARN_UNUSED_RESULT;
+
 int StringToLong(const char *str, long *value_out) FUNC_WARN_UNUSED_RESULT;
 void LogStringToLongError(const char *str_attempted, const char *id, int error_code);
 long StringToLongDefaultOnError(const char *str, long default_return);


### PR DESCRIPTION
Its primary use is the int policy function which
may accept floating point numbers as strings.

Ticket: None
Changelog: None