### PR TITLE
CFE-3648: Added function JsonArrayExtend to libntech

### DIFF
--- a/libutils/json.c
+++ b/libutils/json.c
@@ -1353,6 +1353,24 @@ void JsonArrayAppendElement(
     SeqAppend(array->container.children, element);
 }
 
+void JsonArrayExtend(JsonElement *a, JsonElement *b)
+{
+    assert(a != NULL);
+    assert(a->type == JSON_ELEMENT_TYPE_CONTAINER);
+    assert(a->container.type == JSON_CONTAINER_TYPE_ARRAY);
+    assert(b != NULL);
+    assert(b->type == JSON_ELEMENT_TYPE_CONTAINER);
+    assert(b->container.type == JSON_CONTAINER_TYPE_ARRAY);
+
+    SeqAppendSeq(a->container.children, b->container.children);
+    SeqSoftDestroy(b->container.children);
+    if (b->propertyName != NULL)
+    {
+        free(b->propertyName);
+    }
+    free(b);
+}
+
 void JsonArrayRemoveRange(
     JsonElement *const array, const size_t start, const size_t end)
 {

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -417,6 +417,15 @@ void JsonArrayAppendObject(JsonElement *array, JsonElement *object);
 void JsonArrayAppendElement(JsonElement *array, JsonElement *element);
 
 /**
+  * @brief Move elements from JSON array `b` to JSON array `a`.
+  * @param a [in] The JSON array to move elements to.
+  * @param b [in] The JSON array to move elements from.
+  * @note JSON array `a` takes ownership of elements in JSON array `b`.
+  *       JSON array `b` is freed from memory.
+  */
+void JsonArrayExtend(JsonElement *a, JsonElement *b);
+
+/**
   @brief Remove an inclusive range from a JSON array.
   @see SequenceRemoveRange
   @param array [in] The JSON array parent.

--- a/tests/unit/json_test.c
+++ b/tests/unit/json_test.c
@@ -1405,6 +1405,67 @@ static void test_parse_array_nested_garbage(void)
     }
 }
 
+static void test_array_extend(void)
+{
+    {
+        JsonElement *a = JsonArrayCreate(6);
+        JsonArrayAppendString(a, "one");
+        JsonArrayAppendString(a, "two");
+        JsonArrayAppendString(a, "three");
+
+        JsonElement *b = JsonArrayCreate(3);
+        JsonArrayAppendString(b, "four");
+        JsonArrayAppendString(b, "five");
+        JsonArrayAppendString(b, "six");
+
+        JsonArrayExtend(a, b);
+
+        assert_int_equal(JsonLength(a), 6);
+        assert_string_equal(JsonArrayGetAsString(a, 0), "one");
+        assert_string_equal(JsonArrayGetAsString(a, 1), "two");
+        assert_string_equal(JsonArrayGetAsString(a, 2), "three");
+        assert_string_equal(JsonArrayGetAsString(a, 3), "four");
+        assert_string_equal(JsonArrayGetAsString(a, 4), "five");
+        assert_string_equal(JsonArrayGetAsString(a, 5), "six");
+
+        JsonDestroy(a);
+    }
+    {
+        JsonElement *a = JsonArrayCreate(3);
+        JsonArrayAppendString(a, "one");
+        JsonArrayAppendString(a, "two");
+        JsonArrayAppendString(a, "three");
+
+        JsonElement *b = JsonArrayCreate(0);
+
+        JsonArrayExtend(a, b);
+
+        assert_int_equal(JsonLength(a), 3);
+        assert_string_equal(JsonArrayGetAsString(a, 0), "one");
+        assert_string_equal(JsonArrayGetAsString(a, 1), "two");
+        assert_string_equal(JsonArrayGetAsString(a, 2), "three");
+
+        JsonDestroy(a);
+    }
+    {
+        JsonElement *a = JsonArrayCreate(3);
+
+        JsonElement *b = JsonArrayCreate(3);
+        JsonArrayAppendString(b, "four");
+        JsonArrayAppendString(b, "five");
+        JsonArrayAppendString(b, "six");
+
+        JsonArrayExtend(a, b);
+
+        assert_int_equal(JsonLength(a), 3);
+        assert_string_equal(JsonArrayGetAsString(a, 0), "four");
+        assert_string_equal(JsonArrayGetAsString(a, 1), "five");
+        assert_string_equal(JsonArrayGetAsString(a, 2), "six");
+
+        JsonDestroy(a);
+    }
+}
+
 static void test_array_remove_range(void)
 {
     {
@@ -1732,6 +1793,7 @@ int main()
         unit_test(test_array_get_string),
         unit_test(test_array_iterator),
         unit_test(test_array_remove_range),
+        unit_test(test_array_extend),
         unit_test(test_copy_compare),
         unit_test(test_detach_key_from_object),
         unit_test(test_iterator_current),


### PR DESCRIPTION
Function JsonArrayExtend moves elements from one JSON array to the end
of another JSON array. The first JSON array takes ownership of the
elements of the second JSON array. The second JSON array is freed from
memory.

Ticket: CFE-3648
Changelog: None
Signed-off-by: larsewi <lars.erik.wik@northern.tech>