### PR TITLE
Throw a warning / error when ignoring the return value of StringFormat()

### DIFF
--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -233,7 +233,7 @@ char *StringVFormat(const char *fmt, va_list ap);
  * @return formatted string (on heap) or NULL in case of error. errno is set in
  * the latter case (see errno codes for sprintf).
  */
-char *StringFormat(const char *fmt, ...) FUNC_ATTR_PRINTF(1, 2);
+char *StringFormat(const char *fmt, ...) FUNC_WARN_UNUSED_RESULT FUNC_ATTR_PRINTF(1, 2);
 
 /**
  * @brief Copy a string from `from` to `to` (a buffer of at least buf_size)


### PR DESCRIPTION
Ignoring the return value of this function is always a bug:

* You cannot free the string - Memory leak
* It does nothing useful