### PR TITLE
Actions: Fix apt failures by running update

### DIFF
--- a/.github/workflows/asan_unit_tests.yml
+++ b/.github/workflows/asan_unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl
+      run: sudo apt-get update -y && sudo apt-get install -y libssl-dev libpam0g-dev liblmdb-dev byacc curl
     - name: Run autotools / configure
       run: ./autogen.sh --enable-debug
     - name: Compile and link (make)


### PR DESCRIPTION
These actions started failing with 404 messages sometimes, hope this helps.