### PR TITLE
ENT-6713 Remove unused 3.10.x and 3.12.x from travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
 branches:
   only:
     - master
-    - 3.10.x
-    - 3.12.x
 
 env:
   global:


### PR DESCRIPTION
Ticket: ENT-6713
Changelog: title