### PR TITLE
Add the SeqSoftSet() function

### DIFF
--- a/libutils/sequence.c
+++ b/libutils/sequence.c
@@ -107,6 +107,13 @@ void SeqSet(Seq *seq, size_t index, void *item)
     seq->data[index] = item;
 }
 
+void SeqSoftSet(Seq *seq, size_t index, void *item)
+{
+    assert(seq != NULL);
+    assert(index < SeqLength(seq));
+    seq->data[index] = item;
+}
+
 void SeqAppend(Seq *seq, void *item)
 {
     assert(seq != NULL);

--- a/libutils/sequence.h
+++ b/libutils/sequence.h
@@ -115,7 +115,19 @@ typedef int (*SeqItemComparator) (const void *, const void *, void *user_data);
  */
 int StrCmpWrapper(const void *s1, const void *s2, void *user_data);
 
+/**
+ * Replace value at #index.
+ *
+ * @warning Destroys the original item at #index! See SeqSoftSet().
+ */
 void SeqSet(Seq *set, size_t index, void *item);
+
+/**
+ * Set value at #index.
+ *
+ * @note Make sure the original item at #index is destroyed.
+ */
+void SeqSoftSet(Seq *set, size_t index, void *item);
 
 /**
   @brief Append a new item to the Sequence

--- a/tests/unit/sequence_test.c
+++ b/tests/unit/sequence_test.c
@@ -45,6 +45,31 @@ static void test_append(void)
     SeqDestroy(seq);
 }
 
+static void test_set(void)
+{
+    Seq *seq = SeqNew(10, free);
+    for (size_t i = 0; i < 10; i++)
+    {
+        SeqAppend(seq, xstrdup("snookie"));
+    }
+    assert_int_equal(seq->length, 10);
+
+    SeqSet(seq, 0, xstrdup("blah"));
+    assert_int_equal(seq->length, 10);
+    assert_string_equal(SeqAt(seq, 0), "blah");
+
+    char *item = SeqAt(seq, 5);
+    assert_string_equal(item, "snookie");
+    SeqSoftSet(seq, 5, xstrdup("blah"));
+    assert_int_equal(seq->length, 10);
+    assert_string_equal(SeqAt(seq, 5), "blah");
+
+    /* SeqSoftSet() shouldn't have destroyed the item so we should (be able to)
+     * free it and SeqDestroy() should destroy the replacement. */
+    free(item);
+    SeqDestroy(seq);
+}
+
 static int CompareNumbers(const void *a, const void *b,
                           ARG_UNUSED void *_user_data)
 {
@@ -863,6 +888,7 @@ int main()
     {
         unit_test(test_create_destroy),
         unit_test(test_append),
+        unit_test(test_set),
         unit_test(test_append_once),
         unit_test(test_lookup),
         unit_test(test_binary_lookup),


### PR DESCRIPTION
A function for replacing a value in a sequence without destroying
the replaced value. Useful for moving items away from a sequence
without unnecessary allocations (copying).

Ticket: ENT-5271
Changelog: None