### PR TITLE
Added utility macro for parsing short options

### DIFF
--- a/libutils/misc_lib.h
+++ b/libutils/misc_lib.h
@@ -75,6 +75,46 @@
 
 #define ABS(n)        (  (n<0)  ?  (-n)  :  (n)  )
 
+/**
+ * Hack to get optional- and required-arguments with short options to work the
+ * same way.
+ *
+ *     If the option has an optional argument, it must be written
+ *     directly after the option character if present.
+ *      - getopt(1) - Linux man page
+ *
+ * This means that getopt expects an option "-o" with an optional argument
+ * "foo" to be passed like this: "-ofoo". While an option "-r" with a
+ * required argument "bar" is expected to be passed like this: "-r bar".
+ *
+ * Confusing, right? This little hack makes sure that the option-character and
+ * the optional argument can also be separated by a whitespace-character. This
+ * way optional- and required-arguments can be passed in the same fashion.
+ *
+ * This is how it works:
+ * If optarg is NULL, we check whether the next string in argv is an option
+ * (the variable optind has the index of the next element to be processed in
+ * argv). If this is not the case, we assume it is an argument. The argument
+ * is extracted and optind is advanced accordingly.
+ *
+ * This is how you use it:
+ * ```
+ * case 'o':
+ *     if (OPTIONAL_ARGUMENT_IS_PRESENT)
+ *     {
+ *         // Handle is present
+ *     }
+ *     else
+ *     {
+ *         // Handle is not present
+ *     }
+ *     break;
+ * ```
+ */
+#define OPTIONAL_ARGUMENT_IS_PRESENT \
+    ((optarg == NULL && optind < argc && argv[optind][0] != '-') \
+     ? (bool) (optarg = argv[optind++]) \
+     : (optarg != NULL))
 
 /*
   In contrast to the standard C modulus operator (%), this gives

--- a/tests/unit/misc_lib_test.c
+++ b/tests/unit/misc_lib_test.c
@@ -2,6 +2,7 @@
 
 #include <misc_lib.h>
 #include <alloc.h>
+#include <string_lib.h>
 
 
 static void test_unsigned_modulus(void)
@@ -200,6 +201,175 @@ static void test_ABS(void)
     assert_int_equal(ABS( 2), 2);
 }
 
+static Seq *CheckOpts(int argc, char **argv)
+{
+    Seq *seq = SeqNew(3, free);
+
+    const struct option OPTIONS[] =
+    {
+        {"no-arg", no_argument, 0, 'n'},
+        {"opt-arg", optional_argument, 0, 'o'},
+        {"req-arg", required_argument, 0, 'r'},
+        {NULL, 0, 0, '\0'}
+    };
+
+    /* Reset optind to 1 in order to restart scanning of argv
+     *  - getopt(3) – Linux Manual
+     */
+    optind = 1; 
+
+    int c;
+    while ((c = getopt_long(argc, argv, "no::r:", OPTIONS, NULL)) != -1)
+    {
+        switch (c)
+        {
+        case 'n': /* no argument */
+            SeqAppend(seq, xstrdup("none"));
+            break;
+
+        case 'o': /* optional argument */
+            if (OPTIONAL_ARGUMENT_IS_PRESENT)
+            {
+                SeqAppend(seq, xstrdup(optarg));
+            }
+            else
+            {
+                SeqAppend(seq, xstrdup("default"));
+            }
+            break;
+
+        case 'r': /* required argument */
+            SeqAppend(seq, xstrdup(optarg));
+            break;
+        
+        default:
+            assert(false);
+            break;
+        }
+    }
+
+    return seq;
+}
+
+static void test_GET_OPTIONAL_ARGUMENT(void)
+{
+    /* optional as middle option */
+    int argc1 = 6;
+    char *argv1[] =
+    {
+        "program",
+        "-n",
+        "-o", "foo",
+        "-r", "bar"
+    };
+    Seq *seq1 = CheckOpts(argc1, argv1);
+    assert_int_equal(SeqLength(seq1), 3);
+    assert_string_equal((char *) SeqAt(seq1, 0), "none");
+    assert_string_equal((char *) SeqAt(seq1, 1), "foo");
+    assert_string_equal((char *) SeqAt(seq1, 2), "bar");
+    SeqDestroy(seq1);
+
+    /* optional as last option */
+    int argc2 = 6;
+    char *argv2[] =
+    {
+        "program",
+        "-r", "bar",
+        "-n",
+        "-o", "foo"
+    };
+    Seq *seq2 = CheckOpts(argc2, argv2);
+    assert_int_equal(SeqLength(seq2), 3);
+    assert_string_equal((char *) SeqAt(seq2, 0), "bar");
+    assert_string_equal((char *) SeqAt(seq2, 1), "none");
+    assert_string_equal((char *) SeqAt(seq2, 2), "foo");
+    SeqDestroy(seq2);
+
+    /* optional as first option */
+    int argc3 = 6;
+    char *argv3[] =
+    {
+        "program",
+        "-o", "foo",
+        "-r", "bar",
+        "-n"
+    };
+    Seq *seq3 = CheckOpts(argc3, argv3);
+    assert_int_equal(SeqLength(seq3), 3);
+    assert_string_equal((char *) SeqAt(seq3, 0), "foo");
+    assert_string_equal((char *) SeqAt(seq3, 1), "bar");
+    assert_string_equal((char *) SeqAt(seq3, 2), "none");
+    SeqDestroy(seq3);
+
+    /* optional with no argument */
+    int argc4 = 5;
+    char *argv4[] =
+    {
+        "program",
+        "-n",
+        "-o",
+        "-r", "bar"
+    };
+    Seq *seq4 = CheckOpts(argc4, argv4);
+    assert_int_equal(SeqLength(seq4), 3);
+    assert_string_equal((char *) SeqAt(seq4, 0), "none");
+    assert_string_equal((char *) SeqAt(seq4, 1), "default");
+    assert_string_equal((char *) SeqAt(seq4, 2), "bar");
+    SeqDestroy(seq4);
+
+    /* optional with argument immediately after */
+    int argc5 = 5;
+    char *argv5[] =
+    {
+        "program",
+        "-n",
+        "-ofoo",
+        "-r", "bar"
+    };
+    Seq *seq5 = CheckOpts(argc5, argv5);
+    assert_int_equal(SeqLength(seq5), 3);
+    assert_string_equal((char *) SeqAt(seq5, 0), "none");
+    assert_string_equal((char *) SeqAt(seq5, 1), "foo");
+    assert_string_equal((char *) SeqAt(seq5, 2), "bar");
+    SeqDestroy(seq5);
+
+    /* optional as only option with argument */
+    int argc6 = 3;
+    char *argv6[] =
+    {
+        "program",
+        "-o", "foo"
+    };
+    Seq *seq6 = CheckOpts(argc6, argv6);
+    assert_int_equal(SeqLength(seq6), 1);
+    assert_string_equal((char *) SeqAt(seq6, 0), "foo");
+    SeqDestroy(seq6);
+
+    /* optional as only option with argument immediately after */
+    int argc7 = 2;
+    char *argv7[] =
+    {
+        "program",
+        "-ofoo"
+    };
+    Seq *seq7 = CheckOpts(argc7, argv7);
+    assert_int_equal(SeqLength(seq7), 1);
+    assert_string_equal((char *) SeqAt(seq7, 0), "foo");
+    SeqDestroy(seq7);
+
+    /* optinal as only option with no argument */
+    int argc8 = 2;
+    char *argv8[] =
+    {
+        "program",
+        "-o"
+    };
+    Seq *seq8 = CheckOpts(argc8, argv8);
+    assert_int_equal(SeqLength(seq8), 1);
+    assert_string_equal((char *) SeqAt(seq8, 0), "default");
+    SeqDestroy(seq8);
+}
+
 static void test_putenv_wrapper(void)
 {
     assert_true(getenv("UNIT_TEST_VAR") == NULL);
@@ -248,6 +418,7 @@ int main()
         unit_test(test_rand_ISPOW2),
         unit_test(test_ISPOW2),
         unit_test(test_ABS),
+        unit_test(test_GET_OPTIONAL_ARGUMENT),
         unit_test(test_putenv_wrapper),
         unit_test(test_setenv_wrapper),
     };


### PR DESCRIPTION
Added macro which can be used to support whitespace between
short-option-character and optional-argument.

Ticket: None
Changelog: None
Signed-off-by: larsewi <lars.erik.wik@northern.tech>