### PR TITLE
Add NULL_JSON() and JSON_NOT_NULL() macros

### DIFF
--- a/libutils/json.h
+++ b/libutils/json.h
@@ -186,6 +186,8 @@ const char *JsonElementGetPropertyName(const JsonElement *element);
 
 const char *JsonGetPropertyAsString(const JsonElement *element);
 
+#define NULL_JSON(json) ((json == NULL) || (JsonGetType(json) == JSON_TYPE_NULL))
+#define JSON_NOT_NULL(json) ((json != NULL) && (JsonGetType(json) != JSON_TYPE_NULL))
 
 //////////////////////////////////////////////////////////////////////////////
 // JSON Primitives

--- a/tests/unit/json_test.c
+++ b/tests/unit/json_test.c
@@ -1799,6 +1799,30 @@ static void test_string_escape_json5(void)
     assert_json5_data_eq(7, arr, "\\x01\\x02\\x03\\x04\\x10\\xF0\\xFF");
 }
 
+static void test_json_null_not_null(void)
+{
+    JsonElement *json = NULL;
+    assert_true(NULL_JSON(json));
+    assert_false(JSON_NOT_NULL(json));
+
+    json = JsonObjectCreate(3);
+    assert_true(JSON_NOT_NULL(json));
+    assert_false(NULL_JSON(json));
+
+    JsonObjectAppendInteger(json, "one", 1);
+
+    JsonElement *child = JsonObjectGet(json, "one");
+    assert_true(JSON_NOT_NULL(child));
+    assert_false(NULL_JSON(child));
+
+    JsonObjectAppendNull(json, "two");
+    child = JsonObjectGet(json, "two");
+    assert_true(NULL_JSON(child));
+    assert_false(JSON_NOT_NULL(child));
+
+    JsonDestroy(json);
+}
+
 int main()
 {
     PRINT_TEST_BANNER();
@@ -1866,6 +1890,7 @@ int main()
         unit_test(test_show_string),
         unit_test(test_string_escape),
         unit_test(test_string_escape_json5),
+        unit_test(test_json_null_not_null),
     };
 
     return run_tests(tests);


### PR DESCRIPTION
To check whether a given JsonElement is/isn't NULL or a JSON
'null' value.

Ticket: ENT-7434
Changelog: None