### PR TITLE
Updated copyright notices in .c and .h files to 2022

### DIFF
--- a/libcompat/clock_gettime.c
+++ b/libcompat/clock_gettime.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/closefrom.c
+++ b/libcompat/closefrom.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/dirfd.c
+++ b/libcompat/dirfd.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/drand48.c
+++ b/libcompat/drand48.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/fchmodat.c
+++ b/libcompat/fchmodat.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/fchownat.c
+++ b/libcompat/fchownat.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/fstatat.c
+++ b/libcompat/fstatat.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/generic_at.c
+++ b/libcompat/generic_at.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/generic_at.h
+++ b/libcompat/generic_at.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/gmtime_r.c
+++ b/libcompat/gmtime_r.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/localtime_r.c
+++ b/libcompat/localtime_r.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/log2.c
+++ b/libcompat/log2.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/memdup.c
+++ b/libcompat/memdup.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/memmem.c
+++ b/libcompat/memmem.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/memrchr.c
+++ b/libcompat/memrchr.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/mkdtemp.c
+++ b/libcompat/mkdtemp.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/nanosleep.c
+++ b/libcompat/nanosleep.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/openat.c
+++ b/libcompat/openat.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/poll.c
+++ b/libcompat/poll.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/pthread_attr_setstacksize.c
+++ b/libcompat/pthread_attr_setstacksize.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/pthread_sigmask.c
+++ b/libcompat/pthread_sigmask.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/readlinkat.c
+++ b/libcompat/readlinkat.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/round.c
+++ b/libcompat/round.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/rpl_ctime.c
+++ b/libcompat/rpl_ctime.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/seteuid.c
+++ b/libcompat/seteuid.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/setlinebuf.c
+++ b/libcompat/setlinebuf.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/srand48.c
+++ b/libcompat/srand48.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/stpncpy.c
+++ b/libcompat/stpncpy.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/strcasecmp.c
+++ b/libcompat/strcasecmp.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/strcasestr.c
+++ b/libcompat/strcasestr.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/strdup.c
+++ b/libcompat/strdup.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/strerror.c
+++ b/libcompat/strerror.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/strncasecmp.c
+++ b/libcompat/strncasecmp.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/strsignal.c
+++ b/libcompat/strsignal.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/strstr.c
+++ b/libcompat/strstr.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libcompat/unsetenv.c
+++ b/libcompat/unsetenv.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/alloc.c
+++ b/libutils/alloc.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/alloc.h
+++ b/libutils/alloc.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/array_map.c
+++ b/libutils/array_map.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/array_map_priv.h
+++ b/libutils/array_map_priv.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/buffer.c
+++ b/libutils/buffer.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/buffer.h
+++ b/libutils/buffer.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/cleanup.c
+++ b/libutils/cleanup.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/cleanup.h
+++ b/libutils/cleanup.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/compiler.h
+++ b/libutils/compiler.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/csv_parser.c
+++ b/libutils/csv_parser.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/csv_parser.h
+++ b/libutils/csv_parser.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/csv_writer.c
+++ b/libutils/csv_writer.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/csv_writer.h
+++ b/libutils/csv_writer.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/definitions.h
+++ b/libutils/definitions.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/deprecated.h
+++ b/libutils/deprecated.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/dir.h
+++ b/libutils/dir.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/dir_priv.h
+++ b/libutils/dir_priv.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/encode.c
+++ b/libutils/encode.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/encode.h
+++ b/libutils/encode.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/file_lib.c
+++ b/libutils/file_lib.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/file_lib.h
+++ b/libutils/file_lib.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/hash.c
+++ b/libutils/hash.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/hash.h
+++ b/libutils/hash.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/hash_map.c
+++ b/libutils/hash_map.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/hash_map_priv.h
+++ b/libutils/hash_map_priv.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/hash_method.h
+++ b/libutils/hash_method.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/ip_address.c
+++ b/libutils/ip_address.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/ip_address.h
+++ b/libutils/ip_address.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/json-priv.h
+++ b/libutils/json-priv.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/json-utils.c
+++ b/libutils/json-utils.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/json-utils.h
+++ b/libutils/json-utils.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/json-yaml.c
+++ b/libutils/json-yaml.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/json-yaml.h
+++ b/libutils/json-yaml.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/json.c
+++ b/libutils/json.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/json.h
+++ b/libutils/json.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/known_dirs.c
+++ b/libutils/known_dirs.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/known_dirs.h
+++ b/libutils/known_dirs.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/list.c
+++ b/libutils/list.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/list.h
+++ b/libutils/list.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/logging.h
+++ b/libutils/logging.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/logging_priv.h
+++ b/libutils/logging_priv.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/man.c
+++ b/libutils/man.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 
@@ -31,7 +31,7 @@
 static void WriteCopyright(Writer *out)
 {
     static const char *const copyright =
-        ".\\\"Copyright 2021 Northern.tech AS\n"
+        ".\\\"Copyright 2022 Northern.tech AS\n"
         ".\\\"\n"
         ".\\\"This file is part of CFEngine 3 - written and maintained by Northern.tech AS.\n"
         ".\\\"\n"

--- a/libutils/man.h
+++ b/libutils/man.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/map.c
+++ b/libutils/map.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/map.h
+++ b/libutils/map.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/map_common.h
+++ b/libutils/map_common.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/misc_lib.c
+++ b/libutils/misc_lib.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/misc_lib.h
+++ b/libutils/misc_lib.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/mustache.c
+++ b/libutils/mustache.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/mustache.h
+++ b/libutils/mustache.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/mutex.c
+++ b/libutils/mutex.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/mutex.h
+++ b/libutils/mutex.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/passopenfile.c
+++ b/libutils/passopenfile.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/passopenfile.h
+++ b/libutils/passopenfile.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/path.h
+++ b/libutils/path.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/platform.h
+++ b/libutils/platform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/printsize.h
+++ b/libutils/printsize.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/proc_keyvalue.c
+++ b/libutils/proc_keyvalue.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/proc_keyvalue.h
+++ b/libutils/proc_keyvalue.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/queue.c
+++ b/libutils/queue.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/queue.h
+++ b/libutils/queue.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/rb-tree.c
+++ b/libutils/rb-tree.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/rb-tree.h
+++ b/libutils/rb-tree.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/refcount.c
+++ b/libutils/refcount.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/refcount.h
+++ b/libutils/refcount.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/regex.c
+++ b/libutils/regex.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/regex.h
+++ b/libutils/regex.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/ring_buffer.c
+++ b/libutils/ring_buffer.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/ring_buffer.h
+++ b/libutils/ring_buffer.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/sequence.c
+++ b/libutils/sequence.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/sequence.h
+++ b/libutils/sequence.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/set.c
+++ b/libutils/set.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/set.h
+++ b/libutils/set.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/stack.c
+++ b/libutils/stack.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/stack.h
+++ b/libutils/stack.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/stack_base.c
+++ b/libutils/stack_base.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/statistics.c
+++ b/libutils/statistics.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/statistics.h
+++ b/libutils/statistics.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/string_lib.h
+++ b/libutils/string_lib.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/threaded_deque.c
+++ b/libutils/threaded_deque.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/threaded_deque.h
+++ b/libutils/threaded_deque.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/threaded_queue.c
+++ b/libutils/threaded_queue.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/threaded_queue.h
+++ b/libutils/threaded_queue.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/threaded_stack.c
+++ b/libutils/threaded_stack.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/threaded_stack.h
+++ b/libutils/threaded_stack.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/unicode.c
+++ b/libutils/unicode.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/unicode.h
+++ b/libutils/unicode.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/unix_dir.c
+++ b/libutils/unix_dir.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/writer.c
+++ b/libutils/writer.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/writer.h
+++ b/libutils/writer.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/xml_writer.c
+++ b/libutils/xml_writer.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/libutils/xml_writer.h
+++ b/libutils/xml_writer.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 

--- a/tests/unit/file_lib_test.c
+++ b/tests/unit/file_lib_test.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Northern.tech AS
+  Copyright 2022 Northern.tech AS
 
   This file is part of CFEngine 3 - written and maintained by Northern.tech AS.
 


### PR DESCRIPTION
Ran command:

```
find . -name '*.[hc]' -exec replacer.py 'Copyright 2021 Northern.tech' 'Copyright 2022 Northern.tech' '{}' \;
```

With script from:

https://github.com/olehermanse/dotfiles/blob/4885e5148e0b241905a51d2cfce723eb40ed8447/bin/replacer.py
