### PR TITLE
INVALID: Check that unused variables are caught by CI

### DIFF
--- a/libutils/csv_writer.c
+++ b/libutils/csv_writer.c
@@ -105,6 +105,7 @@ void CsvWriterNewRecord(CsvWriter * csvw)
 
 void CsvWriterClose(CsvWriter * csvw)
 {
+    int unused_variable = 0;
     assert(csvw != NULL);
 
     if (!csvw->beginning_of_line && csvw->terminate_last_line)


### PR DESCRIPTION
These should give a warning and thus error, especially with `-Wall`.