### PR TITLE
CFE-4023: Fixed --with-libxml2=no case in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -571,19 +571,20 @@ if test "x$with_libxml2" != "xno"; then
             LIBXML2_CPPFLAGS=-I$with_libxml2/include/libxml2
         fi
     fi
-fi
 
-CF3_WITH_LIBRARY(libxml2,
-    [AC_CHECK_LIB(xml2, xmlFirstElementChild,
-    [],
-    [if test "x$with_libxml2" != xcheck; then
-        AC_MSG_ERROR(Cannot find libxml2); fi]
-    )
-    AC_CHECK_HEADERS([libxml/xmlwriter.h], [break],
+    CF3_WITH_LIBRARY(libxml2,
+        [AC_CHECK_LIB(xml2, xmlFirstElementChild,
+        [],
         [if test "x$with_libxml2" != xcheck; then
             AC_MSG_ERROR(Cannot find libxml2); fi]
-    )]
-)
+        )
+        AC_CHECK_HEADERS([libxml/xmlwriter.h], [break],
+            [if test "x$with_libxml2" != xcheck; then
+                AC_MSG_ERROR(Cannot find libxml2); fi]
+        )]
+    )
+
+fi
 
 AM_CONDITIONAL([HAVE_LIBXML2],
     [test "x$with_libxml2" != xno &&


### PR DESCRIPTION
The CF3_WITH_LIBRARY and AC_CHECK_HEADERS were moved to outside of the check for with-libxml2=no

Ticket: CFE-4023
Changelog: title