### PR TITLE
ENT-9363: Fixed configure.ac to better recognize openssl with macos homebrew

### DIFF
--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -14,9 +14,9 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: brew install lmdb automake openssl@1.1 pcre
+      run: brew install lmdb automake openssl pcre
     - name: Run autotools / configure
-      run: ./autogen.sh --enable-debug --with-openssl="$(brew --prefix openssl@1.1)"
+      run: ./autogen.sh --enable-debug
     - name: Compile and link
       run: make -j8 CFLAGS="-Werror -Wall"
     - name: Run unit tests

--- a/configure.ac
+++ b/configure.ac
@@ -370,10 +370,10 @@ AC_ARG_WITH(openssl,
     [AS_HELP_STRING([--with-openssl[[=PATH]]],
     [Specify OpenSSL path])], [], [with_openssl=yes])
 
-if  test -d /usr/local/Cellar/openssl/ && \
+if  test -d /usr/local/Cellar/ && \
     test -d /usr/local/opt/openssl/ && \
     test "x$with_openssl" = "xyes" ; then
-    with_openssl="/usr/local/opt/openssl"
+    with_openssl=$(brew --prefix openssl)
     echo "OS X Homebrew detected"
     echo "Defaulting to: --with-openssl=$with_openssl"
 fi


### PR DESCRIPTION
Ticket: ENT-9363
Changelog: title

together:
https://github.com/cfengine/libntech/pull/175
https://github.com/cfengine/core/pull/5180