### PR TITLE
CFE-4080: JSON parser no longer accepts trailing bogus data

### DIFF
--- a/libutils/json.h
+++ b/libutils/json.h
@@ -111,6 +111,7 @@ typedef enum
     JSON_PARSE_ERROR_OBJECT_OPEN_LVAL,
 
     JSON_PARSE_ERROR_INVALID_START,
+    JSON_PARSE_ERROR_INVALID_END,
     JSON_PARSE_ERROR_NO_LIBYAML,
     JSON_PARSE_ERROR_LIBYAML_FAILURE,
     JSON_PARSE_ERROR_NO_SUCH_FILE,
@@ -543,6 +544,18 @@ typedef JsonElement *JsonLookup(void *ctx, const char **data);
   @returns See JsonParseError and JsonParseErrorToString
   */
 JsonParseError JsonParse(const char **data, JsonElement **json_out);
+
+/**
+  @brief Parse the whole string to create a JsonElement
+  @param data [in] Pointer to the string to parse
+  @param json_out Resulting JSON object
+  @note In contrast to JsonParse(), this function will return
+        JSON_PARSE_ERROR_INVALID_END if there are trailing non-whitespace
+        characters after termination of the JsonElement in the remainder of
+        the string.
+  @returns See JsonParseError and JsonParseErrorToString
+  */
+JsonParseError JsonParseAll(const char **data, JsonElement **json_out);
 
 /**
   @brief Parse a string to create a JsonElement

--- a/tests/unit/json_test.c
+++ b/tests/unit/json_test.c
@@ -1294,6 +1294,91 @@ static void test_parse_array_extra_closing(void)
     JsonDestroy(json);
 }
 
+static void test_parse_all(void)
+{
+    const char *data = "\"\"a";
+    JsonElement *json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "\"\""; // Good
+    json = NULL;
+    assert_int_equal(JSON_PARSE_OK, JsonParseAll(&data, &json));
+    assert_true(json != NULL);
+    JsonDestroy(json);
+
+    data = "{}b";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "{}"; // Good
+    json = NULL;
+    assert_int_equal(JSON_PARSE_OK, JsonParseAll(&data, &json));
+    assert_true(json != NULL);
+    JsonDestroy(json);
+
+    data = "[]c";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "{}}";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "{\"d\": \"e\"}}";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "[]]";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "[[]]]";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "[[[]]]]";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "  []]";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "\"some\": [ \"json\" ] }";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "{ \"some\": [ \"json\" ] } [";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "[\"some\", \"json\"]!";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "    [\"some\", \"json\"]a";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+
+    data = "[\"some\", \"json\"] {\"foo\": \"var\"}   ";
+    json = NULL;
+    assert_int_equal(JSON_PARSE_ERROR_INVALID_END, JsonParseAll(&data, &json));
+    assert_true(json == NULL);
+}
+
 static void test_parse_array_diverse(void)
 {
     {
@@ -1848,6 +1933,7 @@ int main()
         unit_test(test_parse_array_diverse),
         unit_test(test_parse_array_double_and_trailing_commas),
         unit_test(test_parse_array_extra_closing),
+        unit_test(test_parse_all),
         unit_test(test_parse_array_garbage),
         unit_test(test_parse_array_nested_garbage),
         unit_test(test_parse_array_object),


### PR DESCRIPTION
JSON parser no longer accepts trailing bogus data (i.e. non-whitespace
characters up until the null-byte).

Merge together with https://github.com/cfengine/core/pull/5191