### PR TITLE
CFE-4185: Support structured logging in libntech

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -440,6 +440,18 @@ else
   AM_CONDITIONAL(WITH_PCRE, false)
 fi
 
+dnl systemd structured logging
+
+AC_ARG_WITH([systemd-logging], [AS_HELP_STRING([--with-systemd-logging[[=PATH]]], [support systemd structured logging])], [], [with_systemd_logging=check])
+
+if test "x$with_systemd_logging" != xno
+then
+   CF3_WITH_LIBRARY(systemd_logging, [
+      AC_CHECK_LIB(systemd, sd_journal_sendv, [], [if test "x$with_systemd_logging" != xcheck; then AC_MSG_ERROR(Cannot find systemd library); fi])
+      AC_CHECK_HEADERS(systemd/sd-journal.h, [], [if test "x$with_systemd_logging" != xcheck; then AC_MSG_ERROR(Cannot find systemd headers); fi])
+   ])
+fi
+
 dnl libvirt
 
 AC_ARG_WITH([libvirt],

--- a/libutils/logging.c
+++ b/libutils/logging.c
@@ -346,6 +346,32 @@ void LogToSystemLogStructured(const int level, ...)
 }
 #endif // defined(HAVE_SYSTEMD_SD_JOURNAL_H) && defined(HAVE_LIBSYSTEMD)
 
+void __ImproperUseOfLogToSystemLogStructured(void)
+{
+    // TODO: CFE-4190
+    //  - Make sure CodeQL finds at least the reqired function calls below,
+    //    then remove this code
+    assert(false); // Do not use this function!
+
+    // Required: Missing required "MESSAGE" key.
+    LogToSystemLogStructured(LOG_LEVEL_DEBUG, "FOO", "bogus", "BAR", "doofus");
+
+    // Required: String-literal "MESSAGE" is not the same as "message".
+    LogToSystemLogStructured(LOG_LEVEL_INFO, "FOO", "bogus", "BAR", "doofus", "message", "Hello CFEngine!");
+
+    // Required: Number of format-string arguments is less than number of format specifiers.
+    LogToSystemLogStructured(LOG_LEVEL_ERR, "MESSAGE", "%s %d", "CFEngine");
+
+    // Optional: Number of format-string arguments is greated than number of format specifiers.
+    LogToSystemLogStructured(LOG_LEVEL_ERR, "MESSAGE", "%s %d", "CFEngine", 123, "ROCKS!");
+
+    // Optional: All keys must be uppercase or else they are ignored.
+    LogToSystemLogStructured(LOG_LEVEL_CRIT, "FOO", "bogus", "bar", "DOOFUS", "MESSAGE", "Hello CFEngine!");
+
+    // Optional: Pairs trailing the "MESSAGE" key are ignored.
+    LogToSystemLogStructured(LOG_LEVEL_NOTICE, "FOO", "bogus", "MESSAGE", "Hello CFEngine!", "BAR", "doofus");
+}
+
 #ifndef __MINGW32__
 const char *GetErrorStrFromCode(int error_code)
 {

--- a/libutils/logging.h
+++ b/libutils/logging.h
@@ -145,6 +145,16 @@ void LogToSystemLog(const char *msg, LogLevel level);
  */
 void LogToSystemLogStructured(LogLevel level, ...);
 
+/**
+ * This function is here, in order to help implement a CodeQL query for
+ * identifying improper use of LogToSystemLogStructured CFE-4185. Once a query
+ * is created, this function should be removed.
+ *
+ * @warning Do not use!
+ * @see CFE-4185
+ */
+void __ImproperUseOfLogToSystemLogStructured(void);
+
 /*
  * Portable strerror(errno)
  */

--- a/libutils/logging.h
+++ b/libutils/logging.h
@@ -128,6 +128,23 @@ void LoggingSetColor(bool enabled);
  */
 void LogToSystemLog(const char *msg, LogLevel level);
 
+/**
+ * @brief Log a message with structured data to system log.
+ * @details This function takes a variable-length argument list and expects
+ *          structured data passed as key-value pairs, where both keys and
+ *          values are C-strings. Furthermore, the last pair must contain the
+ *          "MESSAGE" key, and the corresponding value accepts a format-string
+ *          followed by its arguments. Format-strings are not accepted in the
+ *          value of any other pair. The log priority (i.e., the pair
+ *          containing the "PRIORITY" key) is automatically deduced from the
+ *          log level argument and added to the structured log message.
+ * @note Only the formatted string from the pair with the "MESSAGE" key is
+ *       logged on platforms that does not support structured logging.
+ * @param[in] level Log level.
+ * @param[in] vararg Variable-length argument containing key-value pairs.
+ */
+void LogToSystemLogStructured(LogLevel level, ...);
+
 /*
  * Portable strerror(errno)
  */


### PR DESCRIPTION
- Added function to log structured messages
- CFEngine now uses structured logging
