### PR TITLE
ENT-10428: Removed push event handling in github actions workflow

### DIFF
--- a/.github/workflows/asan_unit_tests.yml
+++ b/.github/workflows/asan_unit_tests.yml
@@ -1,8 +1,6 @@
 name: ASAN Unit Tests
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
   schedule:

--- a/.github/workflows/macos_unit_tests.yml
+++ b/.github/workflows/macos_unit_tests.yml
@@ -1,8 +1,6 @@
 name: MacOS Unit Tests
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,8 +1,6 @@
 name: Unit Tests
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
We don't have easy visibility on the results of these events which only occur after we merge pull requests. We use /merge refs in pull requests so running the actions again on push events (after the merge) don't really provide any additional information.

Pushes/commits to pull requests are handled by the pull_request event so no change there.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push

Ticket: ENT-10428
Changelog: none